### PR TITLE
Improve builder API and README user-friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Output:
 | **Max string length** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Max document size** | ✅ | ✅ | ❌ | ❌ |
 | **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ |
-| **Safe inline JSON logging**² | ✅ | ✅ | ⚠️ Depends | ❌ |
+| **Safe inline JSON logging**² | ✅ | ✅ | ✅ | ❌ |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
 
 > ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` (wildcard), `$..field` (any depth). Full JSONPath spec (filters, functions, slices) is not supported — use [JsonPath](https://github.com/json-path/JsonPath) for that.
@@ -159,16 +159,6 @@ JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(256, 128*1024, "passwor
 JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
 JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email");
 JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, 128*1024, "$.customer.email");
-
-// Remove whole subtrees by field name at any depth
-JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys("appMeta", "diagnostics");
-JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(256, "appMeta");
-JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(256, 128*1024, "appMeta");
-
-// Remove whole subtrees by precise JSONPath
-JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths("$.context.appMeta");
-JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths(256, "$.context.appMeta");
-JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths(256, 128*1024, "$.context.appMeta");
 ```
 
 The same one-liners are available on `JacksonJsonLogFilterBuilder` for untrusted JSON — see the [Jackson module](#jackson-module) section.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Typical use-cases:
 - **GDPR compliance**: anonymize personal data in request/response logging
 - **Log readability**: prune large base64 blobs or low-value subtrees
 - **Log size control**: stay within GCP (256 KB) or Azure (64 KB) per-entry limits
-- **Safe structured logging**: selectively apply core/jacksons filters (to trusted/untrusted JSON) so to always output valid JSON. Then inline filtered JSON directly into a JSON log line — log parsers and ingestors never choke on it
+- **Safe structured logging**: selectively apply core/Jackson filters (to trusted/untrusted JSON) so to always output valid JSON. Then inline filtered JSON directly into a JSON log line — log parsers and ingestors never choke on it
 
 The library automatically selects the most efficient filter implementation for the configured combination of features. 
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,12 @@ Output:
 
 > ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..c` (any depth).
 
-The dual (core + jackson) filter implementation is key to effectively process in/out-going requests/responses while always outputting well-formed JSON. Thus safely embedding filter output as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
-
 Typical use-cases:
 - **Log sanitization**: strip passwords, tokens, and PII before writing to logs
 - **GDPR compliance**: anonymize personal data in request/response logging
 - **Log readability**: prune large base64 blobs or low-value subtrees
 - **Log size control**: stay within GCP (256 KB) or Azure (64 KB) per-entry limits
-- **Safe structured logging**: inline filtered JSON directly into a JSON log line — the output is always valid JSON, so log parsers and ingestors never choke on it
+- **Safe structured logging**: selectively apply core/jacksons filters (to trusted/untrusted JSON) so to always output valid JSON. Then inline filtered JSON directly into a JSON log line — log parsers and ingestors never choke on it
 
 The library automatically selects the most efficient filter implementation for the configured combination of features. No external dependencies are required for the `core` module.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Output:
 | **Safe inline JSON logging**² | ✅ | ✅ | ✅ | ❌ |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
 
-> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..field` (any depth).
+> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..c` (any depth).
 >
 > ² The output is always well-formed JSON, so it can be safely embedded as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Output:
 
 ## Why json-log-filter?
 
-| Feature | **core** (trusted JSON) | **jackson** (untrusted JSON) | Jackson + Manual | Regex |
+| Feature | **json-log-filter core** (trusted JSON) | **json-log-filter jackson** (untrusted JSON) | Jackson + Manual | Regex |
 |---|---|---|---|---|
 | **Performance** | 🏎️ Single-pass, no object model | 🐢 Full parse + serialize | 🐢 Full parse + serialize | 🐌 No structure awareness |
 | **Zero Dependencies** | ✅ | ❌ (Jackson only) | ❌ | ✅ |

--- a/README.md
+++ b/README.md
@@ -341,9 +341,9 @@ A simple syntax is supported where each path segment corresponds to a field name
 `withMaxPathMatches(n)` stops path-based filtering after `n` matches. When the target field appears a known fixed number of times near the start of the document, this lets the filter skip the rest at near pass-through speed.
 
 ```java
-// Stop after finding the single "requestId" field in the header
+// Stop after finding the single "jwt" field
 filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymizePaths("$.header.requestId")
+    .withAnonymizeKeys("jwt")
     .withMaxPathMatches(1)
     .build();
 ```
@@ -402,11 +402,11 @@ Alternative JSON filters:
 
  * [json-masker](https://github.com/Breus/json-masker) slightly different use-case, included in some of the benchmarks.
 
-[Apache 2.0]:			https://www.apache.org/licenses/LICENSE-2.0.html
-[issue-tracker]:		https://github.com/skjolber/json-log-filter/issues
-[Maven]:				https://maven.apache.org/
-[JMH]:					benchmark/jmh
-[xml-log-filter]:      	https://github.com/skjolber/xml-log-filter
-[High-performance]:		https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/docs/benchmark/jmh-result.json&topBar=off
-[Jackson]:				https://github.com/FasterXML/jackson-core
-[JSON]:					https://www.json.org/json-en.html
+[Apache 2.0]:						https://www.apache.org/licenses/LICENSE-2.0.html
+[issue-tracker]:				https://github.com/skjolber/json-log-filter/issues
+[Maven]:								https://maven.apache.org/
+[JMH]:									benchmark/jmh
+[xml-log-filter]:				https://github.com/skjolber/xml-log-filter
+[High-performance]:			https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/docs/benchmark/jmh-result.json&topBar=off
+[Jackson]:							https://github.com/FasterXML/jackson-core
+[JSON]:									https://www.json.org/json-en.html

--- a/README.md
+++ b/README.md
@@ -57,12 +57,11 @@ Output:
 | **Max string length** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Max document size** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ |
-| **Safe inline JSON logging**² | ✅ | ✅ | ✅ | ❌ |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
 
 > ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..c` (any depth).
->
-> ² The output is always well-formed JSON, so it can be safely embedded as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
+
+The dual (core + jackson) filter implementation is key to effectively process in/out-going requests/responses while always outputting well-formed JSON. Thus safely embedding filter output as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
 
 Typical use-cases:
 - **Log sanitization**: strip passwords, tokens, and PII before writing to logs

--- a/README.md
+++ b/README.md
@@ -8,13 +8,8 @@ High-performance filtering of JSON. Reads, filters and writes JSON in a single p
 ## Quick Example
 
 ```java
-// Create once, reuse freely — all filters are thread-safe
-JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.customer.email", "$.customer.ssn")  // replace with "*"
-    .withPrune("$.internal.stackTrace")                   // replace with "PRUNED"
-    .withMaxStringLength(256)                             // truncate long strings
-    .withMaxSize(128 * 1024)                              // drop content beyond 128 KB
-    .build();
+// One-liner for the most common case — all filters are thread-safe, create once and reuse
+JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
 
 String filtered = filter.process(inputJson);
 ```
@@ -22,18 +17,21 @@ String filtered = filter.process(inputJson);
 Input:
 ```json
 {
-  "customer": { "name": "Alice", "email": "alice@example.com", "ssn": "123-45-6789" },
-  "internal": { "stackTrace": "java.lang.Exception: ...(very long)..." }
+  "user": { "name": "Alice", "password": "s3cr3t", "ssn": "123-45-6789" },
+  "auth": { "token": "eyJhbGci..." }
 }
 ```
 
 Output:
 ```json
 {
-  "customer": { "name": "Alice", "email": "*", "ssn": "*" },
-  "internal": { "stackTrace": "PRUNED" }
+  "user": { "name": "Alice", "password": "*", "ssn": "*" },
+  "auth": { "token": "*" }
 }
 ```
+
+> [!TIP]
+> Use [`newBuilder()`](#usage) when you need multiple filter types or extra options like `withMaxStringLength`.
 
 ## Why json-log-filter?
 
@@ -127,49 +125,73 @@ api("com.github.skjolber.json-log-filter:jackson:${jsonLogFilterVersion}")
 
 # Usage
 
-Use `DefaultJsonLogFilterBuilder.newBuilder()` to configure a filter. All produced filters are thread-safe and should be created once and reused.
+## One-liner factory methods
+
+For simple cases, create a ready-to-use filter in a single call:
+
+```java
+// Anonymize fields by name at any depth (most common)
+JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
+
+// Anonymize fields by precise JSONPath
+JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+
+// Remove whole subtrees by field name at any depth
+JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload", "auditLog");
+
+// Remove whole subtrees by precise JSONPath
+JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths("$.context.diagnostics");
+```
+
+The same one-liners are available on `JacksonJsonLogFilterBuilder` for untrusted JSON — see the [Jackson module](#jackson-module) section.
+
+## Builder — multiple filters and extra options
+
+Use `newBuilder()` when you need to combine filter types, customize output text, or set size limits:
 
 ```java
 JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withMaxStringLength(127)          // truncate long string values
-    .withAnonymize("$.customer.email") // replace with "*"
-    .withPrune("$.customer.account")   // replace whole subtree with "PRUNED"
-    .withMaxSize(128 * 1024)           // limit output to 128 KB
+    .withAnonymizeKeys("password", "ssn")        // any depth, by field name
+    .withAnonymizePaths("$.customer.email")       // precise path
+    .withPrunePaths("$.context.rawPayload")       // remove whole subtree
+    .withAnonymizeMessage("[redacted]")           // custom replacement text
+    .withMaxStringLength(256)                     // truncate long strings
+    .withMaxSize(128 * 1024)                      // limit output to 128 KB
     .build();
 
 String filtered = filter.process(inputJson);
 ```
 
+## Keys vs paths
+
+There are two ways to target fields:
+
+| Method | Input | Matches |
+|---|---|---|
+| `withAnonymizeKeys("password")` | bare field name | `password` at **any depth** |
+| `withAnonymizePaths("$.user.password")` | JSONPath expression | `password` only at that **exact path** |
+| `withPruneKeys("rawPayload")` | bare field name | `rawPayload` at **any depth** |
+| `withPrunePaths("$.context.rawPayload")` | JSONPath expression | only at that **exact path** |
+
+`withAnonymizeKeys("password")` is equivalent to `withAnonymizePaths("$..password")`.
+
 ## Adding multiple path filters
 
-Multiple paths can be specified in a single call or across several calls — both are equivalent:
+Multiple paths can be provided in one call, across several calls, or from a collection:
 
 ```java
 // All in one call (varargs)
-filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.customer.email", "$.customer.phone", "$.customer.ssn")
-    .withPrune("$.internal.debug", "$.internal.stackTrace")
-    .build();
-
-// Chained calls
-filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.customer.email")
-    .withAnonymize("$.customer.phone")
-    .withAnonymize("$.customer.ssn")
-    .withPrune("$.internal.debug")
-    .withPrune("$.internal.stackTrace")
-    .build();
+builder.withAnonymizeKeys("password", "ssn", "token")
+       .withPrunePaths("$.context.diagnostics", "$.internal.trace");
 
 // From a collection (List, Set, or any Collection<String>)
-List<String> sensitiveFields = loadSensitiveFieldsFromConfig();
-filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize(sensitiveFields)
-    .build();
+Set<String> sensitiveKeys = loadSensitiveKeysFromConfig();
+builder.withAnonymizeKeys(sensitiveKeys);
 ```
 
 ## Anonymize (mask values)
 
-`withAnonymize(...)` replaces matching scalar values with `"*"`. For objects and arrays, all nested scalars are replaced recursively.
+`withAnonymizeKeys(...)` and `withAnonymizePaths(...)` replace matching scalar values with `"*"`. For objects and arrays, all nested scalars are replaced recursively.
 
 Input:
 ```json
@@ -180,7 +202,7 @@ Input:
 }
 ```
 
-After `.withAnonymize("$.password", "$.credentials")`:
+After `.withAnonymizeKeys("password", "credentials")`:
 ```json
 {
   "username": "alice",
@@ -191,24 +213,27 @@ After `.withAnonymize("$.password", "$.credentials")`:
 
 ## Prune (remove subtrees)
 
-`withPrune(...)` removes entire values — scalars, objects, or arrays — and replaces them with `"PRUNED"`.
+`withPruneKeys(...)` and `withPrunePaths(...)` remove entire values — scalars, objects, or arrays — replacing them with `"PRUNED"`. Useful for large blobs or subtrees with low informational value.
 
 Input:
 ```json
 {
   "header": { "requestId": "abc-123" },
   "context": {
-    "boringData": { "flag1": true, "flag2": false },
-    "staticData": [1, 2, 3, 4, 5]
+    "metadata": { "region": "eu-west-1", "version": "3.2" },
+    "rawPayload": "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7..."
   }
 }
 ```
 
-After `.withPrune("$.context")`:
+After `.withPrunePaths("$.context.rawPayload")`:
 ```json
 {
   "header": { "requestId": "abc-123" },
-  "context": "PRUNED"
+  "context": {
+    "metadata": { "region": "eu-west-1", "version": "3.2" },
+    "rawPayload": "PRUNED"
+  }
 }
 ```
 
@@ -232,8 +257,8 @@ The replacement text for all three operations can be overridden:
 
 ```java
 JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.password")
-    .withPrune("$.debugContext")
+    .withAnonymizeKeys("password")
+    .withPruneKeys("debugContext")
     .withAnonymizeMessage("[redacted]")   // default: "*"
     .withPruneMessage("[removed]")        // default: "PRUNED"
     .withTruncateMessage("…")             // default: "... + <count>"
@@ -268,7 +293,7 @@ A simple syntax is supported where each path segment corresponds to a field name
 ```java
 // Stop after finding the single "requestId" field in the header
 filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.header.requestId")
+    .withAnonymizePaths("$.header.requestId")
     .withMaxPathMatches(1)
     .build();
 ```
@@ -301,8 +326,8 @@ For **untrusted or externally produced JSON**, use `JacksonJsonLogFilterBuilder`
 
 ```java
 JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-    .withAnonymize("$.customer.email", "$.customer.ssn")
-    .withPrune("$.internal.debug")
+    .withAnonymizeKeys("password", "ssn")
+    .withPrunePaths("$.internal.debug")
     .withAnonymizeMessage("[redacted]")
     .build();
 ```

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ After `.withAnonymizeKeys("password", "credentials")`:
 
 ## Prune (remove subtrees)
 
-`withPruneKeys(...)` and `withPrunePaths(...)` remove entire values — scalars, objects, or arrays — replacing them with `"PRUNED"`. The whole subtree is gone in a single replacement.
+`withPruneKeys(...)` and `withPrunePaths(...)` remove entire values — scalars, objects, or arrays — replacing them with `"[removed]"`. The whole subtree is gone in a single replacement.
 
 A common use-case is pruning fields that are always the same across requests (e.g. static application metadata) so they don't waste log space on every request:
 
@@ -280,7 +280,7 @@ After `.withPruneKeys("appMeta")`:
     "method": "POST",
     "path": "/api/orders"
   },
-  "appMeta": "PRUNED"
+  "appMeta": "[removed]"
 }
 ```
 
@@ -313,7 +313,7 @@ JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
     .withAnonymizeKeys("password")
     .withPruneKeys("debugContext")
     .withAnonymizeMessage("[redacted]")   // default: "*"
-    .withPruneMessage("[removed]")        // default: "PRUNED"
+    .withPruneMessage("[removed]")        // default: "[removed]"
     .withTruncateMessage("…")             // default: "... + <count>"
     .build();
 ```

--- a/README.md
+++ b/README.md
@@ -3,30 +3,57 @@
 [![codecov](https://codecov.io/gh/skjolber/json-log-filter/graph/badge.svg?token=8mCiHxVFbz)](https://codecov.io/gh/skjolber/json-log-filter)
 
 # json-log-filter
-High-performance filtering of JSON. Reads, filters and writes JSON in a single step - drastically increasing throughput. Typical use-cases:
+High-performance filtering of JSON. Reads, filters and writes JSON in a single pass — drastically increasing throughput compared to parse-then-serialize approaches.
 
-  * Filter sensitive values from logs (i.e. on request-/response-logging)
-     * technical details like passwords and so on
-     * sensitive personal information, for [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) compliance and such
-  * Improve log readability, filtering
-     * large String elements like base64-encoded binary data, or
-     * whole JSON subtrees with low informational value
-  * Reduce amount of data sent to log accumulation tools
-    * lower cost
-    * potentially reduce search / visualization latency
-    * keep within max log-statement size
-       * GCP: [256 KB](https://cloud.google.com/logging/quotas)
-       * Azure: [64 KB](https://docs.azure.cn/en-us/azure-monitor/fundamentals/service-limits)
+## Quick Example
 
-Features:
+```java
+// Create once, reuse freely — all filters are thread-safe
+JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.customer.email", "$.customer.ssn")  // replace with "*"
+    .withPrune("$.internal.stackTrace")                   // replace with "PRUNED"
+    .withMaxStringLength(256)                             // truncate long strings
+    .withMaxSize(128 * 1024)                              // drop content beyond 128 KB
+    .build();
 
- * Anonymize single values or whole subtrees
- * Remove whole subtrees
- * Limit text value size
- * Limit document size (skip end of document when max size is reached)
- * Remove whitespace
+String filtered = filter.process(inputJson);
+```
 
-The library contains multiple filter implementations as to accommodate combinations of the above features with as little overhead as possible. No external dependencies are required.
+Input:
+```json
+{
+  "customer": { "name": "Alice", "email": "alice@example.com", "ssn": "123-45-6789" },
+  "internal": { "stackTrace": "java.lang.Exception: ...(very long)..." }
+}
+```
+
+Output:
+```json
+{
+  "customer": { "name": "Alice", "email": "*", "ssn": "*" },
+  "internal": { "stackTrace": "PRUNED" }
+}
+```
+
+## Why json-log-filter?
+
+| Feature | json-log-filter | Jackson + Manual | Regex |
+|---|---|---|---|
+| **Performance** | 🏎️ Single-pass, no object model | 🐢 Full parse + serialize | 🐌 No structure awareness |
+| **Zero Dependencies** | ✅ (core) | ❌ | ✅ |
+| **JSONPath Support** | ✅ | ⚠️ Extra lib | ❌ |
+| **Multiple paths at once** | ✅ | ❌ Manual | ❌ |
+| **Prune whole subtrees** | ✅ | ❌ Manual | ❌ |
+| **Max document size** | ✅ | ❌ | ❌ |
+| **Configurable output text** | ✅ | ❌ Manual | ❌ |
+
+Typical use-cases:
+- **Log sanitization**: strip passwords, tokens, PII before writing to logs
+- **GDPR compliance**: anonymize personal data in request/response logging
+- **Log readability**: prune large base64 blobs or low-value subtrees
+- **Log size control**: stay within GCP (256 KB) or Azure (64 KB) limits
+
+The library selects the most efficient filter implementation for the configured combination of features automatically. No external dependencies are required for the `core` module.
 
 Bugs, feature suggestions and help requests can be filed with the [issue-tracker].
 
@@ -99,124 +126,193 @@ api("com.github.skjolber.json-log-filter:jackson:${jsonLogFilterVersion}")
 </details>
 
 # Usage
-Use a `DefaultJsonLogFilterBuilder` to configure a filter instance (all filters are thread safe): 
+
+Use `DefaultJsonLogFilterBuilder.newBuilder()` to configure a filter. All produced filters are thread-safe and should be created once and reused.
 
 ```java
-JsonFilter filter = DefaultJsonLogFilterBuilder.createInstance()
-                       .withMaxStringLength(127) // cuts long texts
-                       .withAnonymize("$.customer.email") // inserts "*" for values
-                       .withPrune("$.customer.account") // removes whole subtree
-                       .withMaxSize(128*1024) // max document size
-                       .build();
-                       
-byte[] json = ...; // obtain JSON
+JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withMaxStringLength(127)          // truncate long string values
+    .withAnonymize("$.customer.email") // replace with "*"
+    .withPrune("$.customer.account")   // replace whole subtree with "PRUNED"
+    .withMaxSize(128 * 1024)           // limit output to 128 KB
+    .build();
 
-String filtered = filter.process(json); // perform filtering                       
+String filtered = filter.process(inputJson);
 ```
 
-### Max string sizes
-Configure max string length for output like
+## Adding multiple path filters
 
+Multiple paths can be specified in a single call or across several calls — both are equivalent:
+
+```java
+// All in one call (varargs)
+filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.customer.email", "$.customer.phone", "$.customer.ssn")
+    .withPrune("$.internal.debug", "$.internal.stackTrace")
+    .build();
+
+// Chained calls
+filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.customer.email")
+    .withAnonymize("$.customer.phone")
+    .withAnonymize("$.customer.ssn")
+    .withPrune("$.internal.debug")
+    .withPrune("$.internal.stackTrace")
+    .build();
+
+// From a collection (List, Set, or any Collection<String>)
+List<String> sensitiveFields = loadSensitiveFieldsFromConfig();
+filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize(sensitiveFields)
+    .build();
+```
+
+## Anonymize (mask values)
+
+`withAnonymize(...)` replaces matching scalar values with `"*"`. For objects and arrays, all nested scalars are replaced recursively.
+
+Input:
 ```json
 {
-    "icon": "QUJDREVGR0hJSktMTU5PUFFSU1... + 46"
+  "username": "alice",
+  "password": "s3cr3t",
+  "credentials": { "token": "abc123", "key": "xyz789" }
 }
 ```
 
-### Anonymize (mask)
-Configure anonymize for output like
-
+After `.withAnonymize("$.password", "$.credentials")`:
 ```json
 {
-    "password": "*"
+  "username": "alice",
+  "password": "*",
+  "credentials": { "token": "*", "key": "*" }
 }
 ```
 
-for scalar values, and/or for objects / arrays all contained scalar values:
+## Prune (remove subtrees)
 
+`withPrune(...)` removes entire values — scalars, objects, or arrays — and replaces them with `"PRUNED"`.
+
+Input:
 ```json
 {
-    "credentials": {
-        "username": "*",
-        "password": "*"
-    }
+  "header": { "requestId": "abc-123" },
+  "context": {
+    "boringData": { "flag1": true, "flag2": false },
+    "staticData": [1, 2, 3, 4, 5]
+  }
 }
 ```
 
-### Remove arrays or objects (prune subtrees) 
-Configure prune to turn input
-
+After `.withPrune("$.context")`:
 ```json
 {
-    "context": {
-        "boringData": {
-        ...
-        },
-        "staticData": [ ... ]
-    }
+  "header": { "requestId": "abc-123" },
+  "context": "PRUNED"
 }
 ```
 
-to output like
+## Truncate long strings
 
+`withMaxStringLength(n)` cuts string values that exceed `n` characters and appends a suffix indicating how many characters were omitted.
+
+Input:
+```json
+{ "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==" }
+```
+
+After `.withMaxStringLength(32)`:
+```json
+{ "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVl... + 46" }
+```
+
+## Customizing output text
+
+The replacement text for all three operations can be overridden:
+
+```java
+JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.password")
+    .withPrune("$.debugContext")
+    .withAnonymizeMessage("[redacted]")   // default: "*"
+    .withPruneMessage("[removed]")        // default: "PRUNED"
+    .withTruncateMessage("…")             // default: "... + <count>"
+    .build();
+```
+
+Output:
 ```json
 {
-    "context": "PRUNED"
+  "password": "[redacted]",
+  "debugContext": "[removed]"
 }
 ```
 
-### Path syntax
-A simple syntax is supported, where each path segment corresponds to a `field name`. Expressions are case-sensitive. Supported syntax:
+## Path syntax
 
-    $.my.field.name
+A simple syntax is supported where each path segment corresponds to a field name. Expressions are case-sensitive.
 
-with support for wildcards; 
-
-    $.my.field.*
-
-or a simple any-level field name search 
-
-    $..myFieldName
+| Syntax | Description | Example |
+|---|---|---|
+| `$.a.b.c` | Exact path | `$.customer.email` |
+| `$.a.b.*` | Wildcard (any field at this level) | `$.customer.*` |
+| `$..fieldName` | Any-level search (all depths) | `$..password` |
 
 > [!NOTE]
-> The filters within this library support using multiple expressions at once. Note that path expressions pass through arrays transparently.
+> Path expressions pass through arrays transparently — `$.items.price` matches `price` inside each element of the `items` array.
 
-### Max path matches
-Configure max path matches; so that filtering stops after a number of matches. This means the __filter speed can be increased considerably if the number of matches is known to be a fixed number__; and will approach pass-through performance if those matches are in the beginning of the document.
+## Max path matches
 
-For example if the to-be filtered JSON document has a schema definition with a header + body structure, and the target value is in the header.   
+`withMaxPathMatches(n)` stops path-based filtering after `n` matches. When the target field appears a known fixed number of times near the start of the document, this lets the filter skip the rest at near pass-through speed.
 
-### Max size
-Configure max size to limit the size of the resulting document.
-
-### Metrics
-Pass in a `JsonFilterMetrics` argument to the `process` method like so:
-
-```
-JsonFilterMetrics myMetrics = new DefaultJsonFilterMetrics();
-String filtered = filter.process(json, myMetrics); // perform filtering
+```java
+// Stop after finding the single "requestId" field in the header
+filter = DefaultJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.header.requestId")
+    .withMaxPathMatches(1)
+    .build();
 ```
 
-The resulting metrics could be logged as metadata alongside the JSON payload or passed to sensors like [Micrometer](https://micrometer.io/) for further processing, for example for
+## Max size
 
- * Measuring the impact of the filtering, i.e. reduction in data size
- * Make sure filters are actually operating as intended
+`withMaxSize(bytes)` limits the size of the output document. Content beyond the limit is dropped.
 
-### Request/response path module
-See the opt-in [path](impl/path) module for help facilitating per-path filters for request/response-logging applications. This to further improve performance.
+## Metrics
 
-### [Jackson] module
-The filters have also been implemented using [Jackson], in an opt-in module.
+Pass a `JsonFilterMetrics` to `process` to measure filtering impact:
 
- * filter + verify document structure in the same operation
- * allows dual filter setup:
-    * trusted (locally produced) JSON: fast filters without strict syntax validation
-    * untrusted (remotely produced) JSON: slower filter with strict syntax validation
+```java
+JsonFilterMetrics metrics = new DefaultJsonFilterMetrics();
+String filtered = filter.process(inputJson, metrics);
+// log or forward metrics.getAnonymizeCount(), metrics.getPruneCount(), etc.
+```
 
-Configure filters from `JacksonJsonLogFilterBuilder`.
+Useful for:
+- Verifying filters are actually matching fields
+- Measuring data reduction sent to log aggregators
+- Feeding [Micrometer](https://micrometer.io/) counters
+
+## Request/response path module
+See the opt-in [path](impl/path) module for per-path filter selection in request/response-logging pipelines, for further performance gains.
+
+## [Jackson] module
+
+For **untrusted or externally produced JSON**, use `JacksonJsonLogFilterBuilder` instead. It validates document structure during filtering at the cost of some throughput.
+
+```java
+JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+    .withAnonymize("$.customer.email", "$.customer.ssn")
+    .withPrune("$.internal.debug")
+    .withAnonymizeMessage("[redacted]")
+    .build();
+```
+
+Typical dual-filter setup:
+- Locally produced JSON → `DefaultJsonLogFilterBuilder` (fast, no validation)
+- Externally received JSON → `JacksonJsonLogFilterBuilder` (validates structure)
 
 ## Performance
-This project trades parser/serializer features for performance, and runs multiple times faster than a "traditional" parser/serializer approach (like when using [Jackson]). 
+This project trades parser/serializer features for performance, running multiple times faster than a traditional parse-then-serialize approach.
 
 See the benchmark results ([JDK 25](https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/benchmark/jmh/results/jmh-results-5.0.0.jdk25.json&topBar=off)) and the [JMH] module for running detailed benchmarks.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ High-performance filtering of JSON. Reads, filters and writes JSON in a single p
 
 ```java
 // One-liner — all filters are thread-safe, create once and reuse
-JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
+JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn", "token"));
 
 String filtered = filter.process(inputJson);
 ```
@@ -147,18 +147,35 @@ api("com.github.skjolber.json-log-filter:jackson:${jsonLogFilterVersion}")
 
 ## One-liner factory methods
 
-For simple cases, create a ready-to-use filter in a single call. All one-liners accept an optional `maxStringLength` and `maxSize`:
+For simple cases, create a ready-to-use filter in a single call.
+
+Use **varargs** when you know the field names up front:
 
 ```java
-// Anonymize fields by name at any depth
+// Anonymize or prune fields by name at any depth
 JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
-JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn");           // + truncate strings > 256 chars
-JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(256, 128*1024, "password", "ssn"); // + cap output at 128 KB
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys("appMeta", "diagnostics");
 
-// Anonymize fields by precise JSONPath
-JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
-JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email");
-JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, 128*1024, "$.customer.email");
+// By precise JSONPath
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email", "$..token");
+JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths("$.context.appMeta");
+```
+
+Use **`Set.of(...)`** when you also need `maxStringLength` or `maxSize`:
+
+```java
+// Anonymize by name — with optional size limits
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"));
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256);              // truncate strings > 256 chars
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256, 128 * 1024);  // + cap output at 128 KB
+
+// Prune whole subtrees — with optional size limits
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta", "diagnostics"));
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256, 128 * 1024);
+
+// By JSONPath — with optional size limits
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email"), 256);
+JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta"), 256, 128 * 1024);
 ```
 
 The same one-liners are available on `JacksonJsonLogFilterBuilder` for untrusted JSON — see the [Jackson module](#jackson-module) section.

--- a/README.md
+++ b/README.md
@@ -401,16 +401,6 @@ Alternative JSON filters:
 
  * [json-masker](https://github.com/Breus/json-masker) slightly different use-case, included in some of the benchmarks.
 
-<<<<<<< HEAD
-[Apache 2.0]:			https://www.apache.org/licenses/LICENSE-2.0.html
-[issue-tracker]:			https://github.com/skjolber/json-log-filter/issues
-[Maven]:					https://maven.apache.org/
-[JMH]:					benchmark/jmh
-[xml-log-filter]:      	https://github.com/skjolber/xml-log-filter
-[High-performance]:		https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/docs/benchmark/jmh-result.json&topBar=off
-[Jackson]:				https://github.com/FasterXML/jackson-core
-[JSON]:					https://www.json.org/json-en.html
-=======
 [Apache 2.0]:						https://www.apache.org/licenses/LICENSE-2.0.html
 [issue-tracker]:				https://github.com/skjolber/json-log-filter/issues
 [Maven]:								https://maven.apache.org/
@@ -419,4 +409,3 @@ Alternative JSON filters:
 [High-performance]:			https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/docs/benchmark/jmh-result.json&topBar=off
 [Jackson]:							https://github.com/FasterXML/jackson-core
 [JSON]:									https://www.json.org/json-en.html
->>>>>>> 718e7b5cfebb2e7c4d125e2e0e72d2385a9d4bd4

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Output:
 
 | Feature | **core** (trusted JSON) | **jackson** (untrusted JSON) | Jackson + Manual | Regex |
 |---|---|---|---|---|
-| **Performance** | 🏎️ Single-pass, no object model | 🚗 Single-pass + structure validation | 🐢 Full parse + serialize | 🐌 No structure awareness |
+| **Performance** | 🏎️ Single-pass, no object model | 🐢 Full parse + serialize | 🐢 Full parse + serialize | 🐌 No structure awareness |
 | **Zero Dependencies** | ✅ | ❌ (Jackson only) | ❌ | ✅ |
 | **JSONPath Support** | ✅ subset¹ | ✅ subset¹ | ⚠️ Extra lib | ❌ |
 | **Match at any depth** | ✅ (`$..field`) | ✅ (`$..field`) | ❌ Manual | ❌ |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # json-log-filter
 High-performance filtering of JSON. Reads, filters and writes JSON in a single pass — drastically increasing throughput compared to parse-then-serialize approaches.
 
-## Quick Example
+## Quickstart
 
 ```java
 // One-liner — all filters are thread-safe, create once and reuse
@@ -15,6 +15,7 @@ String filtered = filter.process(inputJson);
 ```
 
 Input:
+
 ```json
 {
   "user": {
@@ -29,6 +30,7 @@ Input:
 ```
 
 Output:
+
 ```json
 {
   "user": {
@@ -68,7 +70,7 @@ Typical use-cases:
 - **Log size control**: stay within GCP (256 KB) or Azure (64 KB) per-entry limits
 - **Safe structured logging**: selectively apply core/jacksons filters (to trusted/untrusted JSON) so to always output valid JSON. Then inline filtered JSON directly into a JSON log line — log parsers and ingestors never choke on it
 
-The library automatically selects the most efficient filter implementation for the configured combination of features. No external dependencies are required for the `core` module.
+The library automatically selects the most efficient filter implementation for the configured combination of features. 
 
 Bugs, feature suggestions and help requests can be filed with the [issue-tracker].
 
@@ -183,7 +185,7 @@ Use `newBuilder()` when you need to combine filter types, customize output text,
 
 ```java
 JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
-    .withAnonymizeKeys("password", "ssn")        // any depth, by field name
+    .withAnonymizeKeys("password", "ssn")         // any depth, by field name
     .withAnonymizePaths("$.customer.email")       // precise path
     .withPrunePaths("$.context.rawPayload")       // remove whole subtree
     .withAnonymizeMessage("[redacted]")           // custom replacement text
@@ -362,9 +364,8 @@ String filtered = filter.process(inputJson, metrics);
 // log or forward metrics.getAnonymizeCount(), metrics.getPruneCount(), etc.
 ```
 
-Useful for:
-- Verifying filters are actually matching fields
-- Measuring data reduction sent to log aggregators
+Useful for measuring data reduction;
+- Flagging that data has been removed
 - Feeding [Micrometer](https://micrometer.io/) counters
 
 ## Request/response path module
@@ -403,8 +404,8 @@ Alternative JSON filters:
  * [json-masker](https://github.com/Breus/json-masker) slightly different use-case, included in some of the benchmarks.
 
 [Apache 2.0]:			https://www.apache.org/licenses/LICENSE-2.0.html
-[issue-tracker]:		https://github.com/skjolber/json-log-filter/issues
-[Maven]:				https://maven.apache.org/
+[issue-tracker]:			https://github.com/skjolber/json-log-filter/issues
+[Maven]:					https://maven.apache.org/
 [JMH]:					benchmark/jmh
 [xml-log-filter]:      	https://github.com/skjolber/xml-log-filter
 [High-performance]:		https://jmh.morethan.io/?source=https://raw.githubusercontent.com/skjolber/json-log-filter/master/docs/benchmark/jmh-result.json&topBar=off

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ High-performance filtering of JSON. Reads, filters and writes JSON in a single p
 ## Quick Example
 
 ```java
-// One-liner for the most common case — all filters are thread-safe, create once and reuse
+// One-liner — all filters are thread-safe, create once and reuse
 JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
 
 String filtered = filter.process(inputJson);
@@ -17,41 +17,61 @@ String filtered = filter.process(inputJson);
 Input:
 ```json
 {
-  "user": { "name": "Alice", "password": "s3cr3t", "ssn": "123-45-6789" },
-  "auth": { "token": "eyJhbGci..." }
+  "user": {
+    "name": "Alice",
+    "password": "s3cr3t",
+    "ssn": "123-45-6789"
+  },
+  "auth": {
+    "token": "eyJhbGci..."
+  }
 }
 ```
 
 Output:
 ```json
 {
-  "user": { "name": "Alice", "password": "*", "ssn": "*" },
-  "auth": { "token": "*" }
+  "user": {
+    "name": "Alice",
+    "password": "*",
+    "ssn": "*"
+  },
+  "auth": {
+    "token": "*"
+  }
 }
 ```
 
 > [!TIP]
-> Use [`newBuilder()`](#usage) when you need multiple filter types or extra options like `withMaxStringLength`.
+> Use [`newBuilder()`](#builder--multiple-filters-and-extra-options) when you need to combine filter types or set extra options.
 
 ## Why json-log-filter?
 
-| Feature | json-log-filter | Jackson + Manual | Regex |
-|---|---|---|---|
-| **Performance** | 🏎️ Single-pass, no object model | 🐢 Full parse + serialize | 🐌 No structure awareness |
-| **Zero Dependencies** | ✅ (core) | ❌ | ✅ |
-| **JSONPath Support** | ✅ | ⚠️ Extra lib | ❌ |
-| **Multiple paths at once** | ✅ | ❌ Manual | ❌ |
-| **Prune whole subtrees** | ✅ | ❌ Manual | ❌ |
-| **Max document size** | ✅ | ❌ | ❌ |
-| **Configurable output text** | ✅ | ❌ Manual | ❌ |
+| Feature | **core** (trusted JSON) | **jackson** (untrusted JSON) | Jackson + Manual | Regex |
+|---|---|---|---|---|
+| **Performance** | 🏎️ Single-pass, no object model | 🚗 Single-pass + structure validation | 🐢 Full parse + serialize | 🐌 No structure awareness |
+| **Zero Dependencies** | ✅ | ❌ (Jackson only) | ❌ | ✅ |
+| **JSONPath Support** | ✅ subset¹ | ✅ subset¹ | ⚠️ Extra lib | ❌ |
+| **Match at any depth** | ✅ (`$..field`) | ✅ (`$..field`) | ❌ Manual | ❌ |
+| **Prune whole subtrees** | ✅ | ✅ | ❌ Manual | ❌ |
+| **Max string length** | ✅ | ✅ | ❌ Manual | ❌ |
+| **Max document size** | ✅ | ✅ | ❌ | ❌ |
+| **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ |
+| **Safe inline JSON logging**² | ✅ | ✅ | ⚠️ Depends | ❌ |
+| **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
+
+> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` (wildcard), `$..field` (any depth). Full JSONPath spec (filters, functions, slices) is not supported — use [JsonPath](https://github.com/json-path/JsonPath) for that.
+>
+> ² The output is always well-formed JSON, so it can be safely embedded as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
 
 Typical use-cases:
-- **Log sanitization**: strip passwords, tokens, PII before writing to logs
+- **Log sanitization**: strip passwords, tokens, and PII before writing to logs
 - **GDPR compliance**: anonymize personal data in request/response logging
 - **Log readability**: prune large base64 blobs or low-value subtrees
-- **Log size control**: stay within GCP (256 KB) or Azure (64 KB) limits
+- **Log size control**: stay within GCP (256 KB) or Azure (64 KB) per-entry limits
+- **Safe structured logging**: inline filtered JSON directly into a JSON log line — the output is always valid JSON, so log parsers and ingestors never choke on it
 
-The library selects the most efficient filter implementation for the configured combination of features automatically. No external dependencies are required for the `core` module.
+The library automatically selects the most efficient filter implementation for the configured combination of features. No external dependencies are required for the `core` module.
 
 Bugs, feature suggestions and help requests can be filed with the [issue-tracker].
 
@@ -127,20 +147,28 @@ api("com.github.skjolber.json-log-filter:jackson:${jsonLogFilterVersion}")
 
 ## One-liner factory methods
 
-For simple cases, create a ready-to-use filter in a single call:
+For simple cases, create a ready-to-use filter in a single call. All one-liners accept an optional `maxStringLength` and `maxSize`:
 
 ```java
-// Anonymize fields by name at any depth (most common)
-JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
+// Anonymize fields by name at any depth
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn");           // + truncate strings > 256 chars
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(256, 128*1024, "password", "ssn"); // + cap output at 128 KB
 
 // Anonymize fields by precise JSONPath
-JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email");
+JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths(256, 128*1024, "$.customer.email");
 
 // Remove whole subtrees by field name at any depth
-JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload", "auditLog");
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys("appMeta", "diagnostics");
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(256, "appMeta");
+JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(256, 128*1024, "appMeta");
 
 // Remove whole subtrees by precise JSONPath
-JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths("$.context.diagnostics");
+JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths("$.context.appMeta");
+JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths(256, "$.context.appMeta");
+JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths(256, 128*1024, "$.context.appMeta");
 ```
 
 The same one-liners are available on `JacksonJsonLogFilterBuilder` for untrusted JSON — see the [Jackson module](#jackson-module) section.
@@ -198,7 +226,10 @@ Input:
 {
   "username": "alice",
   "password": "s3cr3t",
-  "credentials": { "token": "abc123", "key": "xyz789" }
+  "credentials": {
+    "token": "abc123",
+    "key": "xyz789"
+  }
 }
 ```
 
@@ -207,35 +238,47 @@ After `.withAnonymizeKeys("password", "credentials")`:
 {
   "username": "alice",
   "password": "*",
-  "credentials": { "token": "*", "key": "*" }
+  "credentials": {
+    "token": "*",
+    "key": "*"
+  }
 }
 ```
 
 ## Prune (remove subtrees)
 
-`withPruneKeys(...)` and `withPrunePaths(...)` remove entire values — scalars, objects, or arrays — replacing them with `"PRUNED"`. Useful for large blobs or subtrees with low informational value.
+`withPruneKeys(...)` and `withPrunePaths(...)` remove entire values — scalars, objects, or arrays — replacing them with `"PRUNED"`. The whole subtree is gone in a single replacement.
+
+A common use-case is pruning fields that are always the same across requests (e.g. static application metadata) so they don't waste log space on every request:
 
 Input:
 ```json
 {
-  "header": { "requestId": "abc-123" },
-  "context": {
-    "metadata": { "region": "eu-west-1", "version": "3.2" },
-    "rawPayload": "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7..."
+  "request": {
+    "method": "POST",
+    "path": "/api/orders"
+  },
+  "appMeta": {
+    "version": "2.3.1",
+    "region": "eu-west-1",
+    "buildTime": "2026-01-15T08:30:00Z",
+    "dependencies": ["service-A", "service-B", "service-C"]
   }
 }
 ```
 
-After `.withPrunePaths("$.context.rawPayload")`:
+After `.withPruneKeys("appMeta")`:
 ```json
 {
-  "header": { "requestId": "abc-123" },
-  "context": {
-    "metadata": { "region": "eu-west-1", "version": "3.2" },
-    "rawPayload": "PRUNED"
-  }
+  "request": {
+    "method": "POST",
+    "path": "/api/orders"
+  },
+  "appMeta": "PRUNED"
 }
 ```
+
+The entire `appMeta` object — including its nested array — is replaced by a single string token.
 
 ## Truncate long strings
 
@@ -243,12 +286,16 @@ After `.withPrunePaths("$.context.rawPayload")`:
 
 Input:
 ```json
-{ "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==" }
+{
+  "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=="
+}
 ```
 
 After `.withMaxStringLength(32)`:
 ```json
-{ "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVl... + 46" }
+{
+  "icon": "QUJDREVGR0hJSktMTU5PUFFSU1RVVl... + 46"
+}
 ```
 
 ## Customizing output text
@@ -272,7 +319,6 @@ Output:
   "debugContext": "[removed]"
 }
 ```
-
 ## Path syntax
 
 A simple syntax is supported where each path segment corresponds to a field name. Expressions are case-sensitive.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Multiple paths can be provided in one call, across several calls, or from a coll
 
 ```java
 // All in one call (varargs)
-builder.withAnonymizeKeys("password", "ssn", "token")
+builder.withAnonymizeKeys("ssn", "token")
        .withPrunePaths("$.context.diagnostics", "$.internal.trace");
 
 // From a collection (List, Set, or any Collection<String>)
@@ -227,8 +227,8 @@ builder.withAnonymizeKeys(sensitiveKeys);
 Input:
 ```json
 {
-  "username": "alice",
-  "password": "s3cr3t",
+  "username": "skjolber",
+  "name": "Thomas Skjølberg",
   "credentials": {
     "token": "abc123",
     "key": "xyz789"
@@ -236,11 +236,11 @@ Input:
 }
 ```
 
-After `.withAnonymizeKeys("password", "credentials")`:
+After `.withAnonymizeKeys("name", "credentials")`:
 ```json
 {
-  "username": "alice",
-  "password": "*",
+  "username": "skjolber",
+  "fullName": "*",
   "credentials": {
     "token": "*",
     "key": "*"
@@ -335,6 +335,8 @@ A simple syntax is supported where each path segment corresponds to a field name
 > [!NOTE]
 > Path expressions pass through arrays transparently — `$.items.price` matches `price` inside each element of the `items` array.
 
+Using full paths generally improves performance.
+
 ## Max path matches
 
 `withMaxPathMatches(n)` stops path-based filtering after `n` matches. When the target field appears a known fixed number of times near the start of the document, this lets the filter skip the rest at near pass-through speed.
@@ -380,7 +382,7 @@ JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
     .build();
 ```
 
-Typical dual-filter setup:
+Typical dual-filter setup in a webserver:
 - Locally produced JSON → `DefaultJsonLogFilterBuilder` (fast, no validation)
 - Externally received JSON → `JacksonJsonLogFilterBuilder` (validates structure)
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,15 @@ Output:
 | Feature | **json-log-filter core** (trusted JSON) | **json-log-filter jackson** (untrusted JSON) | Jackson + Manual | Regex |
 |---|---|---|---|---|
 | **Performance** | 🏎️ Single-pass, no object model | 🐢 Full parse + serialize | 🐢 Full parse + serialize | 🐌 No structure awareness |
-| **Zero Dependencies** | ✅ | ❌ (Jackson only) | ❌ | ✅ |
+| **Zero Dependencies** | ✅ | ❌ (Jackson) | ❌ (Jackson) | ✅ |
 | **JSONPath Support** | ✅ subset¹ | ✅ subset¹ | ⚠️ Extra lib | ❌ |
-| **Match at any depth** | ✅ (`$..field`) | ✅ (`$..field`) | ❌ Manual | ❌ |
 | **Prune whole subtrees** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Max string length** | ✅ | ✅ | ❌ Manual | ❌ |
-| **Max document size** | ✅ | ✅ | ❌ Manual | ❌ |
-| **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ |
+| **Max document size** | ✅ | ✅ | ❌ Manual | ❌ Manual |
+| **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ Manual |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
 
-> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..c` (any depth).
+> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..c` (`c` at any depth).
 
 Typical use-cases:
 - **Log sanitization**: strip passwords, tokens, and PII before writing to logs
@@ -311,7 +310,7 @@ JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
     .withAnonymizeKeys("password")
     .withPruneKeys("debugContext")
     .withAnonymizeMessage("[redacted]")   // default: "*"
-    .withPruneMessage("[removed]")        // default: "[removed]"
+    .withPruneMessage("[skipped]")        // default: "[removed]"
     .withTruncateMessage("…")             // default: "... + <count>"
     .build();
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Output:
 | **Safe inline JSON logging**² | ✅ | ✅ | ✅ | ❌ |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |
 
-> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` (wildcard), `$..field` (any depth). Full JSONPath spec (filters, functions, slices) is not supported — use [JsonPath](https://github.com/json-path/JsonPath) for that.
+> ¹ Supported path syntax: `$.a.b.c` (exact), `$.a.b.*` / `$.a.*.c` (wildcard), `$..field` (any depth).
 >
 > ² The output is always well-formed JSON, so it can be safely embedded as an inline raw JSON value in structured log entries (e.g. as a field in a JSON log line) without escaping or breaking the outer log parser.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Output:
 | **Match at any depth** | ✅ (`$..field`) | ✅ (`$..field`) | ❌ Manual | ❌ |
 | **Prune whole subtrees** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Max string length** | ✅ | ✅ | ❌ Manual | ❌ |
-| **Max document size** | ✅ | ✅ | ❌ | ❌ |
+| **Max document size** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Configurable output text** | ✅ | ✅ | ❌ Manual | ❌ |
 | **Safe inline JSON logging**² | ✅ | ✅ | ✅ | ❌ |
 | **Structural validation** | ❌ (trusted input) | ✅ | ✅ | ❌ |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ High-performance filtering of JSON. Reads, filters and writes JSON in a single p
 
 ```java
 // One-liner — all filters are thread-safe, create once and reuse
-JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn", "token"));
+JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn", "token");
 
 String filtered = filter.process(inputJson);
 ```
@@ -18,8 +18,7 @@ Input:
 ```json
 {
   "user": {
-    "name": "Alice",
-    "password": "s3cr3t",
+    "type": "member",
     "ssn": "123-45-6789"
   },
   "auth": {
@@ -32,8 +31,7 @@ Output:
 ```json
 {
   "user": {
-    "name": "Alice",
-    "password": "*",
+    "type": "member",
     "ssn": "*"
   },
   "auth": {

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonFilter.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonFilter.java
@@ -8,7 +8,7 @@ import com.github.skjolber.jsonfilter.ResizableByteArrayOutputStream;
 
 public abstract class AbstractJsonFilter implements JsonFilter {
 
-	public static final String FILTER_PRUNE_MESSAGE = "PRUNED";
+	public static final String FILTER_PRUNE_MESSAGE = "[removed]";
 	public static final String FILTER_ANONYMIZE = "*";
 	public static final String FILTER_TRUNCATE_MESSAGE = "... + ";
 

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
@@ -215,7 +215,7 @@ return self();
 /**
  * Remove (prune) the subtrees matched by the given JSONPath expressions. The entire
  * value – whether a scalar, object, or array – is replaced by the prune
- * placeholder (default {@code "PRUNED"}).
+ * placeholder (default {@code "[removed]"}).
  *
  * <p>Use {@link #withPruneKeys} when you want to match a field name at
  * <em>any</em> depth without writing a full path.
@@ -294,7 +294,7 @@ return self();
  * Set the replacement text inserted in place of pruned subtrees.
  * The value is automatically JSON-escaped and wrapped in quotes.
  *
- * <p>Default: {@code "PRUNED"}
+ * <p>Default: {@code "[removed]"}
  *
  * @param value the unescaped replacement text (e.g. {@code "[removed]"})
  * @return this builder

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	   http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,15 +28,22 @@ import java.util.List;
  * output customization, and size constraints. Concrete subclasses supply the
  * {@link #build()} method that wires the settings into a specific filter implementation.
  *
- * <p>Example usage:
+ * <p>Two ways to target fields:
+ * <ul>
+ *   <li>{@code withAnonymizePaths} / {@code withPrunePaths} – precise JSONPath expressions
+ *       (e.g. {@code "$.customer.email"})</li>
+ *   <li>{@code withAnonymizeKeys} / {@code withPruneKeys} – bare field names matched at
+ *       <em>any</em> depth (e.g. {@code "password"} matches everywhere)</li>
+ * </ul>
+ *
+ * <p>Example:
  * <pre>{@code
  * JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
- *     .withMaxStringLength(127)
- *     .withAnonymize("$.customer.email", "$.customer.ssn")
- *     .withPrune("$.customer.account", "$.internal.debug")
+ *     .withAnonymizeKeys("password", "ssn")           // any depth
+ *     .withAnonymizePaths("$.customer.email")          // precise path
+ *     .withPrunePaths("$.context.rawPayload")          // remove whole subtree
  *     .withAnonymizeMessage("[redacted]")
- *     .withPruneMessage("[removed]")
- *     .withMaxSize(128 * 1024)
+ *     .withMaxStringLength(256)
  *     .build();
  * }</pre>
  *
@@ -44,282 +51,396 @@ import java.util.List;
  */
 public abstract class AbstractJsonLogFilterBuilder<B extends AbstractJsonLogFilterBuilder<B>> {
 
-	protected int maxStringLength = -1;
-	protected int maxPathMatches = -1;
-	protected int maxSize = -1;
-	protected boolean removeWhitespace = false;
+protected int maxStringLength = -1;
+protected int maxPathMatches = -1;
+protected int maxSize = -1;
+protected boolean removeWhitespace = false;
 
-	protected List<String> anonymizeFilters = new ArrayList<>();
-	protected List<String> pruneFilters = new ArrayList<>();
+protected List<String> anonymizeFilters = new ArrayList<>();
+protected List<String> pruneFilters = new ArrayList<>();
 
-	/** Raw JSON value used to replace pruned nodes */
-	protected String pruneJsonValue;
-	/** Raw JSON value used to replace anonymized values */
-	protected String anonymizeJsonValue;
-	/** Raw (escaped) JSON string suffix appended after truncated text */
-	protected String truncateStringValue;
+/** Raw JSON value used to replace pruned nodes */
+protected String pruneJsonValue;
+/** Raw JSON value used to replace anonymized values */
+protected String anonymizeJsonValue;
+/** Raw (escaped) JSON string suffix appended after truncated text */
+protected String truncateStringValue;
 
-	@SuppressWarnings("unchecked")
-	protected B self() {
-		return (B) this;
-	}
+@SuppressWarnings("unchecked")
+protected B self() {
+return (B) this;
+}
 
-	/**
-	 * Build and return a configured, thread-safe filter instance.
-	 *
-	 * @return a new {@linkplain com.github.skjolber.jsonfilter.JsonFilter}
-	 */
-	public abstract com.github.skjolber.jsonfilter.JsonFilter build();
+/**
+ * Build and return a configured, thread-safe filter instance.
+ *
+ * @return a new {@linkplain com.github.skjolber.jsonfilter.JsonFilter}
+ */
+public abstract com.github.skjolber.jsonfilter.JsonFilter build();
 
-	// -------------------------------------------------------------------------
-	// Size / limit settings
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// Size / limit settings
+// -------------------------------------------------------------------------
 
-	/**
-	 * Limit the length of string values in the output. Strings exceeding this
-	 * length are truncated and a suffix (configurable via {@link #withTruncateMessage})
-	 * is appended.
-	 *
-	 * @param length maximum number of characters per string value
-	 * @return this builder
-	 */
-	public B withMaxStringLength(int length) {
-		this.maxStringLength = length;
-		return self();
-	}
+/**
+ * Limit the length of string values in the output. Strings exceeding this
+ * length are truncated and a suffix (configurable via {@link #withTruncateMessage})
+ * is appended.
+ *
+ * @param length maximum number of characters per string value
+ * @return this builder
+ */
+public B withMaxStringLength(int length) {
+this.maxStringLength = length;
+return self();
+}
 
-	/**
-	 * Stop path-based filtering after this many matches. Useful when the target
-	 * field appears a known number of times near the beginning of the document,
-	 * as the filter can then skip the remainder at near pass-through speed.
-	 *
-	 * @param maxPathMatches maximum number of path matches before filtering stops
-	 * @return this builder
-	 */
-	public B withMaxPathMatches(int maxPathMatches) {
-		this.maxPathMatches = maxPathMatches;
-		return self();
-	}
+/**
+ * Stop path-based filtering after this many matches. Useful when the target
+ * field appears a known number of times near the beginning of the document,
+ * as the filter can then skip the remainder at near pass-through speed.
+ *
+ * @param maxPathMatches maximum number of path matches before filtering stops
+ * @return this builder
+ */
+public B withMaxPathMatches(int maxPathMatches) {
+this.maxPathMatches = maxPathMatches;
+return self();
+}
 
-	/**
-	 * Limit the size of the output document. Content beyond the limit is dropped.
-	 *
-	 * @param maxSize maximum output size in bytes
-	 * @return this builder
-	 */
-	public B withMaxSize(int maxSize) {
-		this.maxSize = maxSize;
-		return self();
-	}
+/**
+ * Limit the size of the output document. Content beyond the limit is dropped.
+ *
+ * @param maxSize maximum output size in bytes
+ * @return this builder
+ */
+public B withMaxSize(int maxSize) {
+this.maxSize = maxSize;
+return self();
+}
 
-	/**
-	 * Remove all insignificant whitespace from the output.
-	 *
-	 * @param removeWhitespace {@code true} to strip whitespace
-	 * @return this builder
-	 */
-	public B withRemoveWhitespace(boolean removeWhitespace) {
-		this.removeWhitespace = removeWhitespace;
-		return self();
-	}
+/**
+ * Remove all insignificant whitespace from the output.
+ *
+ * @param removeWhitespace {@code true} to strip whitespace
+ * @return this builder
+ */
+public B withRemoveWhitespace(boolean removeWhitespace) {
+this.removeWhitespace = removeWhitespace;
+return self();
+}
 
-	// -------------------------------------------------------------------------
-	// Path filters – anonymize
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// Anonymize by JSONPath (precise)
+// -------------------------------------------------------------------------
 
-	/**
-	 * Anonymize the values at the given JSONPath expressions. Scalar values are
-	 * replaced by the anonymize placeholder (default {@code "*"}); object and
-	 * array values have all their nested scalars replaced recursively.
-	 *
-	 * <p>May be called multiple times to accumulate expressions:
-	 * <pre>{@code
-	 * builder.withAnonymize("$.customer.email")
-	 *        .withAnonymize("$.customer.phone");
-	 * }</pre>
-	 * or in a single call:
-	 * <pre>{@code
-	 * builder.withAnonymize("$.customer.email", "$.customer.phone");
-	 * }</pre>
-	 *
-	 * @param filters one or more JSONPath expressions
-	 * @return this builder
-	 */
-	public B withAnonymize(String... filters) {
-		Collections.addAll(anonymizeFilters, filters);
-		return self();
-	}
+/**
+ * Anonymize the values matched by the given JSONPath expressions.
+ * Scalar values are replaced by the anonymize placeholder (default {@code "*"});
+ * objects and arrays have all their nested scalars replaced recursively.
+ *
+ * <p>Use {@link #withAnonymizeKeys} when you want to match a field name at
+ * <em>any</em> depth without writing a full path.
+ *
+ * <pre>{@code
+ * builder.withAnonymizePaths("$.customer.email", "$.customer.phone");
+ * }</pre>
+ *
+ * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
+ * @return this builder
+ */
+public B withAnonymizePaths(String... expressions) {
+Collections.addAll(anonymizeFilters, expressions);
+return self();
+}
 
-	/**
-	 * Anonymize the values at the given JSONPath expressions.
-	 *
-	 * @param filters collection of JSONPath expressions
-	 * @return this builder
-	 * @see #withAnonymize(String...)
-	 */
-	public B withAnonymize(Collection<String> filters) {
-		anonymizeFilters.addAll(filters);
-		return self();
-	}
+/**
+ * Anonymize the values matched by the given JSONPath expressions.
+ *
+ * @param expressions collection of JSONPath expressions
+ * @return this builder
+ * @see #withAnonymizePaths(String...)
+ */
+public B withAnonymizePaths(Collection<String> expressions) {
+anonymizeFilters.addAll(expressions);
+return self();
+}
 
-	// -------------------------------------------------------------------------
-	// Path filters – prune
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// Anonymize by key name (any depth)
+// -------------------------------------------------------------------------
 
-	/**
-	 * Remove (prune) the subtrees at the given JSONPath expressions. The entire
-	 * value – whether a scalar, object, or array – is replaced by the prune
-	 * placeholder (default {@code "PRUNED"}).
-	 *
-	 * <p>May be called multiple times to accumulate expressions:
-	 * <pre>{@code
-	 * builder.withPrune("$.internal.debug")
-	 *        .withPrune("$.internal.trace");
-	 * }</pre>
-	 * or in a single call:
-	 * <pre>{@code
-	 * builder.withPrune("$.internal.debug", "$.internal.trace");
-	 * }</pre>
-	 *
-	 * @param filters one or more JSONPath expressions
-	 * @return this builder
-	 */
-	public B withPrune(String... filters) {
-		Collections.addAll(pruneFilters, filters);
-		return self();
-	}
+/**
+ * Anonymize every value whose field name matches any of the given keys,
+ * regardless of where in the document the field appears.
+ *
+ * <p>Equivalent to calling {@code withAnonymizePaths("$..<key>")} for each key.
+ * Use {@link #withAnonymizePaths} when you need a precise path instead.
+ *
+ * <pre>{@code
+ * builder.withAnonymizeKeys("password", "ssn", "token");
+ * // equivalent to:
+ * builder.withAnonymizePaths("$..password", "$..ssn", "$..token");
+ * }</pre>
+ *
+ * @param keys one or more bare field names (e.g. {@code "password"})
+ * @return this builder
+ */
+public B withAnonymizeKeys(String... keys) {
+for (String key : keys) {
+anonymizeFilters.add("$.." + key);
+}
+return self();
+}
 
-	/**
-	 * Remove (prune) the subtrees at the given JSONPath expressions.
-	 *
-	 * @param filters collection of JSONPath expressions
-	 * @return this builder
-	 * @see #withPrune(String...)
-	 */
-	public B withPrune(Collection<String> filters) {
-		pruneFilters.addAll(filters);
-		return self();
-	}
+/**
+ * Anonymize every value whose field name matches any key in the collection,
+ * regardless of depth.
+ *
+ * @param keys collection of bare field names
+ * @return this builder
+ * @see #withAnonymizeKeys(String...)
+ */
+public B withAnonymizeKeys(Collection<String> keys) {
+for (String key : keys) {
+anonymizeFilters.add("$.." + key);
+}
+return self();
+}
 
-	// -------------------------------------------------------------------------
-	// Output customization
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// Prune by JSONPath (precise)
+// -------------------------------------------------------------------------
 
-	/**
-	 * Set the replacement text inserted in place of pruned subtrees.
-	 * The value is automatically JSON-escaped and wrapped in quotes.
-	 *
-	 * <p>Default: {@code "PRUNED"}
-	 *
-	 * @param value the unescaped replacement text (e.g. {@code "[removed]"})
-	 * @return this builder
-	 */
-	public B withPruneMessage(String value) {
-		StringBuilder sb = new StringBuilder(value.length() * 2);
-		sb.append('"');
-		AbstractJsonFilter.quoteAsString(value, sb);
-		sb.append('"');
-		return withPruneRawJsonValue(sb.toString());
-	}
+/**
+ * Remove (prune) the subtrees matched by the given JSONPath expressions. The entire
+ * value – whether a scalar, object, or array – is replaced by the prune
+ * placeholder (default {@code "PRUNED"}).
+ *
+ * <p>Use {@link #withPruneKeys} when you want to match a field name at
+ * <em>any</em> depth without writing a full path.
+ *
+ * <pre>{@code
+ * builder.withPrunePaths("$.context.rawPayload", "$.context.auditLog");
+ * }</pre>
+ *
+ * @param expressions one or more JSONPath expressions
+ * @return this builder
+ */
+public B withPrunePaths(String... expressions) {
+Collections.addAll(pruneFilters, expressions);
+return self();
+}
 
-	/**
-	 * Set the replacement text inserted in place of anonymized values.
-	 * The value is automatically JSON-escaped and wrapped in quotes.
-	 *
-	 * <p>Default: {@code "*"}
-	 *
-	 * @param value the unescaped replacement text (e.g. {@code "[redacted]"})
-	 * @return this builder
-	 */
-	public B withAnonymizeMessage(String value) {
-		StringBuilder sb = new StringBuilder(value.length() * 2);
-		sb.append('"');
-		AbstractJsonFilter.quoteAsString(value, sb);
-		sb.append('"');
-		return withAnonymizeRawJsonValue(sb.toString());
-	}
+/**
+ * Remove (prune) the subtrees matched by the given JSONPath expressions.
+ *
+ * @param expressions collection of JSONPath expressions
+ * @return this builder
+ * @see #withPrunePaths(String...)
+ */
+public B withPrunePaths(Collection<String> expressions) {
+pruneFilters.addAll(expressions);
+return self();
+}
 
-	/**
-	 * Set the suffix appended after truncated string values.
-	 * The value is automatically JSON-escaped (but not quoted, as it is
-	 * embedded inside an existing string value).
-	 *
-	 * <p>Default: {@code "... + "} followed by the number of omitted characters.
-	 *
-	 * @param value the unescaped suffix text (e.g. {@code "…"})
-	 * @return this builder
-	 */
-	public B withTruncateMessage(String value) {
-		StringBuilder sb = new StringBuilder(value.length() * 2);
-		AbstractJsonFilter.quoteAsString(value, sb);
-		return withTruncateRawJsonStringValue(sb.toString());
-	}
+// -------------------------------------------------------------------------
+// Prune by key name (any depth)
+// -------------------------------------------------------------------------
 
-	// -------------------------------------------------------------------------
-	// Raw JSON value overrides (for advanced / pre-escaped use)
-	// -------------------------------------------------------------------------
+/**
+ * Remove (prune) every subtree whose field name matches any of the given keys,
+ * regardless of where in the document the field appears.
+ *
+ * <p>Equivalent to calling {@code withPrunePaths("$..<key>")} for each key.
+ * Use {@link #withPrunePaths} when you need a precise path instead.
+ *
+ * <pre>{@code
+ * builder.withPruneKeys("rawPayload", "auditLog");
+ * // equivalent to:
+ * builder.withPrunePaths("$..rawPayload", "$..auditLog");
+ * }</pre>
+ *
+ * @param keys one or more bare field names (e.g. {@code "rawPayload"})
+ * @return this builder
+ */
+public B withPruneKeys(String... keys) {
+for (String key : keys) {
+pruneFilters.add("$.." + key);
+}
+return self();
+}
 
-	/**
-	 * Set the raw JSON value used to replace pruned nodes.
-	 * The value must be valid, pre-escaped JSON (e.g. {@code "\"PRUNED\""}).
-	 *
-	 * @param raw a valid JSON value
-	 * @return this builder
-	 */
-	public B withPruneRawJsonValue(String raw) {
-		this.pruneJsonValue = raw;
-		return self();
-	}
+/**
+ * Remove (prune) every subtree whose field name matches any key in the collection,
+ * regardless of depth.
+ *
+ * @param keys collection of bare field names
+ * @return this builder
+ * @see #withPruneKeys(String...)
+ */
+public B withPruneKeys(Collection<String> keys) {
+for (String key : keys) {
+pruneFilters.add("$.." + key);
+}
+return self();
+}
 
-	/**
-	 * Set the raw JSON value used to replace anonymized values.
-	 * The value must be valid, pre-escaped JSON (e.g. {@code "\"*\""}).
-	 *
-	 * @param raw a valid JSON value
-	 * @return this builder
-	 */
-	public B withAnonymizeRawJsonValue(String raw) {
-		this.anonymizeJsonValue = raw;
-		return self();
-	}
+// -------------------------------------------------------------------------
+// Output customization
+// -------------------------------------------------------------------------
 
-	/**
-	 * Set the raw (pre-escaped) JSON string suffix appended after truncated text.
-	 * The value must already be JSON-string-escaped (no surrounding quotes).
-	 *
-	 * @param escaped a pre-escaped JSON string fragment
-	 * @return this builder
-	 */
-	public B withTruncateRawJsonStringValue(String escaped) {
-		this.truncateStringValue = escaped;
-		return self();
-	}
+/**
+ * Set the replacement text inserted in place of pruned subtrees.
+ * The value is automatically JSON-escaped and wrapped in quotes.
+ *
+ * <p>Default: {@code "PRUNED"}
+ *
+ * @param value the unescaped replacement text (e.g. {@code "[removed]"})
+ * @return this builder
+ */
+public B withPruneMessage(String value) {
+StringBuilder sb = new StringBuilder(value.length() * 2);
+sb.append('"');
+AbstractJsonFilter.quoteAsString(value, sb);
+sb.append('"');
+return withPruneRawJsonValue(sb.toString());
+}
 
-	// -------------------------------------------------------------------------
-	// Deprecated aliases for backwards compatibility
-	// -------------------------------------------------------------------------
+/**
+ * Set the replacement text inserted in place of anonymized values.
+ * The value is automatically JSON-escaped and wrapped in quotes.
+ *
+ * <p>Default: {@code "*"}
+ *
+ * @param value the unescaped replacement text (e.g. {@code "[redacted]"})
+ * @return this builder
+ */
+public B withAnonymizeMessage(String value) {
+StringBuilder sb = new StringBuilder(value.length() * 2);
+sb.append('"');
+AbstractJsonFilter.quoteAsString(value, sb);
+sb.append('"');
+return withAnonymizeRawJsonValue(sb.toString());
+}
 
-	/**
-	 * @deprecated Use {@link #withPruneMessage(String)} instead.
-	 */
-	@Deprecated
-	public B withPruneStringValue(String value) {
-		return withPruneMessage(value);
-	}
+/**
+ * Set the suffix appended after truncated string values.
+ * The value is automatically JSON-escaped (but not quoted, as it is
+ * embedded inside an existing string value).
+ *
+ * <p>Default: {@code "... + "} followed by the number of omitted characters.
+ *
+ * @param value the unescaped suffix text (e.g. {@code "…"})
+ * @return this builder
+ */
+public B withTruncateMessage(String value) {
+StringBuilder sb = new StringBuilder(value.length() * 2);
+AbstractJsonFilter.quoteAsString(value, sb);
+return withTruncateRawJsonStringValue(sb.toString());
+}
 
-	/**
-	 * @deprecated Use {@link #withAnonymizeMessage(String)} instead.
-	 */
-	@Deprecated
-	public B withAnonymizeStringValue(String value) {
-		return withAnonymizeMessage(value);
-	}
+// -------------------------------------------------------------------------
+// Raw JSON value overrides (for advanced / pre-escaped use)
+// -------------------------------------------------------------------------
 
-	/**
-	 * @deprecated Use {@link #withTruncateMessage(String)} instead.
-	 */
-	@Deprecated
-	public B withTruncateStringValue(String value) {
-		return withTruncateMessage(value);
-	}
+/**
+ * Set the raw JSON value used to replace pruned nodes.
+ * The value must be valid, pre-escaped JSON (e.g. {@code "\"PRUNED\""}).
+ *
+ * @param raw a valid JSON value
+ * @return this builder
+ */
+public B withPruneRawJsonValue(String raw) {
+this.pruneJsonValue = raw;
+return self();
+}
+
+/**
+ * Set the raw JSON value used to replace anonymized values.
+ * The value must be valid, pre-escaped JSON (e.g. {@code "\"*\""}).
+ *
+ * @param raw a valid JSON value
+ * @return this builder
+ */
+public B withAnonymizeRawJsonValue(String raw) {
+this.anonymizeJsonValue = raw;
+return self();
+}
+
+/**
+ * Set the raw (pre-escaped) JSON string suffix appended after truncated text.
+ * The value must already be JSON-string-escaped (no surrounding quotes).
+ *
+ * @param escaped a pre-escaped JSON string fragment
+ * @return this builder
+ */
+public B withTruncateRawJsonStringValue(String escaped) {
+this.truncateStringValue = escaped;
+return self();
+}
+
+// -------------------------------------------------------------------------
+// Deprecated aliases for backwards compatibility
+// -------------------------------------------------------------------------
+
+/**
+ * @deprecated Use {@link #withAnonymizePaths(String...)} for JSONPath expressions,
+ *             or {@link #withAnonymizeKeys(String...)} for bare field names.
+ */
+@Deprecated
+public B withAnonymize(String... filters) {
+return withAnonymizePaths(filters);
+}
+
+/**
+ * @deprecated Use {@link #withAnonymizePaths(Collection)} for JSONPath expressions,
+ *             or {@link #withAnonymizeKeys(Collection)} for bare field names.
+ */
+@Deprecated
+public B withAnonymize(Collection<String> filters) {
+return withAnonymizePaths(filters);
+}
+
+/**
+ * @deprecated Use {@link #withPrunePaths(String...)} for JSONPath expressions,
+ *             or {@link #withPruneKeys(String...)} for bare field names.
+ */
+@Deprecated
+public B withPrune(String... filters) {
+return withPrunePaths(filters);
+}
+
+/**
+ * @deprecated Use {@link #withPrunePaths(Collection)} for JSONPath expressions,
+ *             or {@link #withPruneKeys(Collection)} for bare field names.
+ */
+@Deprecated
+public B withPrune(Collection<String> filters) {
+return withPrunePaths(filters);
+}
+
+/**
+ * @deprecated Use {@link #withPruneMessage(String)} instead.
+ */
+@Deprecated
+public B withPruneStringValue(String value) {
+return withPruneMessage(value);
+}
+
+/**
+ * @deprecated Use {@link #withAnonymizeMessage(String)} instead.
+ */
+@Deprecated
+public B withAnonymizeStringValue(String value) {
+return withAnonymizeMessage(value);
+}
+
+/**
+ * @deprecated Use {@link #withTruncateMessage(String)} instead.
+ */
+@Deprecated
+public B withTruncateStringValue(String value) {
+return withTruncateMessage(value);
+}
 }

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
@@ -443,4 +443,5 @@ return withAnonymizeMessage(value);
 public B withTruncateStringValue(String value) {
 return withTruncateMessage(value);
 }
+
 }

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractJsonLogFilterBuilder.java
@@ -1,0 +1,325 @@
+/***************************************************************************
+ * Copyright 2020 Thomas Rorvik Skjolberg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.github.skjolber.jsonfilter.base;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Abstract base builder for {@linkplain com.github.skjolber.jsonfilter.JsonFilter} instances.
+ *
+ * <p>Provides a fluent API for configuring path-based filtering (anonymize/prune),
+ * output customization, and size constraints. Concrete subclasses supply the
+ * {@link #build()} method that wires the settings into a specific filter implementation.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
+ *     .withMaxStringLength(127)
+ *     .withAnonymize("$.customer.email", "$.customer.ssn")
+ *     .withPrune("$.customer.account", "$.internal.debug")
+ *     .withAnonymizeMessage("[redacted]")
+ *     .withPruneMessage("[removed]")
+ *     .withMaxSize(128 * 1024)
+ *     .build();
+ * }</pre>
+ *
+ * @param <B> the concrete builder type, for fluent chaining
+ */
+public abstract class AbstractJsonLogFilterBuilder<B extends AbstractJsonLogFilterBuilder<B>> {
+
+	protected int maxStringLength = -1;
+	protected int maxPathMatches = -1;
+	protected int maxSize = -1;
+	protected boolean removeWhitespace = false;
+
+	protected List<String> anonymizeFilters = new ArrayList<>();
+	protected List<String> pruneFilters = new ArrayList<>();
+
+	/** Raw JSON value used to replace pruned nodes */
+	protected String pruneJsonValue;
+	/** Raw JSON value used to replace anonymized values */
+	protected String anonymizeJsonValue;
+	/** Raw (escaped) JSON string suffix appended after truncated text */
+	protected String truncateStringValue;
+
+	@SuppressWarnings("unchecked")
+	protected B self() {
+		return (B) this;
+	}
+
+	/**
+	 * Build and return a configured, thread-safe filter instance.
+	 *
+	 * @return a new {@linkplain com.github.skjolber.jsonfilter.JsonFilter}
+	 */
+	public abstract com.github.skjolber.jsonfilter.JsonFilter build();
+
+	// -------------------------------------------------------------------------
+	// Size / limit settings
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Limit the length of string values in the output. Strings exceeding this
+	 * length are truncated and a suffix (configurable via {@link #withTruncateMessage})
+	 * is appended.
+	 *
+	 * @param length maximum number of characters per string value
+	 * @return this builder
+	 */
+	public B withMaxStringLength(int length) {
+		this.maxStringLength = length;
+		return self();
+	}
+
+	/**
+	 * Stop path-based filtering after this many matches. Useful when the target
+	 * field appears a known number of times near the beginning of the document,
+	 * as the filter can then skip the remainder at near pass-through speed.
+	 *
+	 * @param maxPathMatches maximum number of path matches before filtering stops
+	 * @return this builder
+	 */
+	public B withMaxPathMatches(int maxPathMatches) {
+		this.maxPathMatches = maxPathMatches;
+		return self();
+	}
+
+	/**
+	 * Limit the size of the output document. Content beyond the limit is dropped.
+	 *
+	 * @param maxSize maximum output size in bytes
+	 * @return this builder
+	 */
+	public B withMaxSize(int maxSize) {
+		this.maxSize = maxSize;
+		return self();
+	}
+
+	/**
+	 * Remove all insignificant whitespace from the output.
+	 *
+	 * @param removeWhitespace {@code true} to strip whitespace
+	 * @return this builder
+	 */
+	public B withRemoveWhitespace(boolean removeWhitespace) {
+		this.removeWhitespace = removeWhitespace;
+		return self();
+	}
+
+	// -------------------------------------------------------------------------
+	// Path filters – anonymize
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Anonymize the values at the given JSONPath expressions. Scalar values are
+	 * replaced by the anonymize placeholder (default {@code "*"}); object and
+	 * array values have all their nested scalars replaced recursively.
+	 *
+	 * <p>May be called multiple times to accumulate expressions:
+	 * <pre>{@code
+	 * builder.withAnonymize("$.customer.email")
+	 *        .withAnonymize("$.customer.phone");
+	 * }</pre>
+	 * or in a single call:
+	 * <pre>{@code
+	 * builder.withAnonymize("$.customer.email", "$.customer.phone");
+	 * }</pre>
+	 *
+	 * @param filters one or more JSONPath expressions
+	 * @return this builder
+	 */
+	public B withAnonymize(String... filters) {
+		Collections.addAll(anonymizeFilters, filters);
+		return self();
+	}
+
+	/**
+	 * Anonymize the values at the given JSONPath expressions.
+	 *
+	 * @param filters collection of JSONPath expressions
+	 * @return this builder
+	 * @see #withAnonymize(String...)
+	 */
+	public B withAnonymize(Collection<String> filters) {
+		anonymizeFilters.addAll(filters);
+		return self();
+	}
+
+	// -------------------------------------------------------------------------
+	// Path filters – prune
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Remove (prune) the subtrees at the given JSONPath expressions. The entire
+	 * value – whether a scalar, object, or array – is replaced by the prune
+	 * placeholder (default {@code "PRUNED"}).
+	 *
+	 * <p>May be called multiple times to accumulate expressions:
+	 * <pre>{@code
+	 * builder.withPrune("$.internal.debug")
+	 *        .withPrune("$.internal.trace");
+	 * }</pre>
+	 * or in a single call:
+	 * <pre>{@code
+	 * builder.withPrune("$.internal.debug", "$.internal.trace");
+	 * }</pre>
+	 *
+	 * @param filters one or more JSONPath expressions
+	 * @return this builder
+	 */
+	public B withPrune(String... filters) {
+		Collections.addAll(pruneFilters, filters);
+		return self();
+	}
+
+	/**
+	 * Remove (prune) the subtrees at the given JSONPath expressions.
+	 *
+	 * @param filters collection of JSONPath expressions
+	 * @return this builder
+	 * @see #withPrune(String...)
+	 */
+	public B withPrune(Collection<String> filters) {
+		pruneFilters.addAll(filters);
+		return self();
+	}
+
+	// -------------------------------------------------------------------------
+	// Output customization
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Set the replacement text inserted in place of pruned subtrees.
+	 * The value is automatically JSON-escaped and wrapped in quotes.
+	 *
+	 * <p>Default: {@code "PRUNED"}
+	 *
+	 * @param value the unescaped replacement text (e.g. {@code "[removed]"})
+	 * @return this builder
+	 */
+	public B withPruneMessage(String value) {
+		StringBuilder sb = new StringBuilder(value.length() * 2);
+		sb.append('"');
+		AbstractJsonFilter.quoteAsString(value, sb);
+		sb.append('"');
+		return withPruneRawJsonValue(sb.toString());
+	}
+
+	/**
+	 * Set the replacement text inserted in place of anonymized values.
+	 * The value is automatically JSON-escaped and wrapped in quotes.
+	 *
+	 * <p>Default: {@code "*"}
+	 *
+	 * @param value the unescaped replacement text (e.g. {@code "[redacted]"})
+	 * @return this builder
+	 */
+	public B withAnonymizeMessage(String value) {
+		StringBuilder sb = new StringBuilder(value.length() * 2);
+		sb.append('"');
+		AbstractJsonFilter.quoteAsString(value, sb);
+		sb.append('"');
+		return withAnonymizeRawJsonValue(sb.toString());
+	}
+
+	/**
+	 * Set the suffix appended after truncated string values.
+	 * The value is automatically JSON-escaped (but not quoted, as it is
+	 * embedded inside an existing string value).
+	 *
+	 * <p>Default: {@code "... + "} followed by the number of omitted characters.
+	 *
+	 * @param value the unescaped suffix text (e.g. {@code "…"})
+	 * @return this builder
+	 */
+	public B withTruncateMessage(String value) {
+		StringBuilder sb = new StringBuilder(value.length() * 2);
+		AbstractJsonFilter.quoteAsString(value, sb);
+		return withTruncateRawJsonStringValue(sb.toString());
+	}
+
+	// -------------------------------------------------------------------------
+	// Raw JSON value overrides (for advanced / pre-escaped use)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Set the raw JSON value used to replace pruned nodes.
+	 * The value must be valid, pre-escaped JSON (e.g. {@code "\"PRUNED\""}).
+	 *
+	 * @param raw a valid JSON value
+	 * @return this builder
+	 */
+	public B withPruneRawJsonValue(String raw) {
+		this.pruneJsonValue = raw;
+		return self();
+	}
+
+	/**
+	 * Set the raw JSON value used to replace anonymized values.
+	 * The value must be valid, pre-escaped JSON (e.g. {@code "\"*\""}).
+	 *
+	 * @param raw a valid JSON value
+	 * @return this builder
+	 */
+	public B withAnonymizeRawJsonValue(String raw) {
+		this.anonymizeJsonValue = raw;
+		return self();
+	}
+
+	/**
+	 * Set the raw (pre-escaped) JSON string suffix appended after truncated text.
+	 * The value must already be JSON-string-escaped (no surrounding quotes).
+	 *
+	 * @param escaped a pre-escaped JSON string fragment
+	 * @return this builder
+	 */
+	public B withTruncateRawJsonStringValue(String escaped) {
+		this.truncateStringValue = escaped;
+		return self();
+	}
+
+	// -------------------------------------------------------------------------
+	// Deprecated aliases for backwards compatibility
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @deprecated Use {@link #withPruneMessage(String)} instead.
+	 */
+	@Deprecated
+	public B withPruneStringValue(String value) {
+		return withPruneMessage(value);
+	}
+
+	/**
+	 * @deprecated Use {@link #withAnonymizeMessage(String)} instead.
+	 */
+	@Deprecated
+	public B withAnonymizeStringValue(String value) {
+		return withAnonymizeMessage(value);
+	}
+
+	/**
+	 * @deprecated Use {@link #withTruncateMessage(String)} instead.
+	 */
+	@Deprecated
+	public B withTruncateStringValue(String value) {
+		return withTruncateMessage(value);
+	}
+}

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractRangesFilter.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/AbstractRangesFilter.java
@@ -12,7 +12,7 @@ public abstract class AbstractRangesFilter {
 	protected static final int FILTER_DELETE = 2;
 	protected static final int FILTER_MAX_LENGTH = 3;
 	
-	public static final String FILTER_PRUNE_MESSAGE = "PRUNED";
+	public static final String FILTER_PRUNE_MESSAGE = "[removed]";
 	public static final String FILTER_PRUNE_MESSAGE_JSON = '"' + FILTER_PRUNE_MESSAGE + '"';
 	
 	public static final String FILTER_ANONYMIZE = "*";

--- a/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
+++ b/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
@@ -1,5 +1,7 @@
 package com.github.skjolber.jsonfilter.jackson;
 
+import java.util.Set;
+
 import com.github.skjolber.jsonfilter.JsonFilter;
 import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
 
@@ -14,17 +16,17 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  *
  * <p>Quick one-liner factory methods for the most common cases:
  * <pre>{@code
- * // Anonymize fields by name at any depth
+ * // Anonymize fields by name at any depth — varargs
  * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
  *
- * // Anonymize fields by precise JSONPath
- * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+ * // Anonymize fields by name — Set with optional size limits
+ * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"));
+ * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256);
+ * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256, 128 * 1024);
  *
- * // Remove whole subtrees by name at any depth
- * JsonFilter f = JacksonJsonLogFilterBuilder.pruneKeys("rawPayload");
- *
- * // Remove whole subtrees by precise JSONPath
- * JsonFilter f = JacksonJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+ * // Remove whole subtrees by field name — Set with optional size limits
+ * JsonFilter f = JacksonJsonLogFilterBuilder.pruneKeys(Set.of("appMeta", "diagnostics"));
+ * JsonFilter f = JacksonJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256, 128 * 1024);
  * }</pre>
  *
  * <p>Use {@link #newBuilder()} for more control:
@@ -41,186 +43,240 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  */
 public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<JacksonJsonLogFilterBuilder> {
 
-	/**
-	 * Create a new builder instance.
-	 *
-	 * @return a fresh {@linkplain JacksonJsonLogFilterBuilder}
-	 */
-	public static JacksonJsonLogFilterBuilder newBuilder() {
-		return new JacksonJsonLogFilterBuilder();
-	}
+/**
+ * Create a new builder instance.
+ *
+ * @return a fresh {@linkplain JacksonJsonLogFilterBuilder}
+ */
+public static JacksonJsonLogFilterBuilder newBuilder() {
+return new JacksonJsonLogFilterBuilder();
+}
 
-	// -------------------------------------------------------------------------
-	// Static one-liner factory methods
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// One-liners: anonymize by key name
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that anonymizes every field matching any of the given keys,
-	 * at any depth in the document.
-	 *
-	 * @param keys one or more bare field names (e.g. {@code "password"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(String... keys) {
-		return newBuilder().withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes every field matching any of the given keys,
+ * at any depth in the document.
+ *
+ * @param keys one or more bare field names (e.g. {@code "password"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(String... keys) {
+return newBuilder().withAnonymizeKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by key name and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(int maxStringLength, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes every field matching any key in the set,
+ * at any depth in the document.
+ *
+ * @param keys set of bare field names (e.g. {@code Set.of("password", "ssn")})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys) {
+return newBuilder().withAnonymizeKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by key name, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(int maxStringLength, int maxSize, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by key name and truncates long strings.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys, int maxStringLength) {
+return newBuilder().withAnonymizeKeys(keys).withMaxStringLength(maxStringLength).build();
+}
 
-	/**
-	 * Create a filter that anonymizes the values at the given JSONPath expressions.
-	 *
-	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(String... expressions) {
-		return newBuilder().withAnonymizePaths(expressions).build();
-	}
+/**
+ * Create a filter that anonymizes fields by key name, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys, int maxStringLength, int maxSize) {
+return newBuilder().withAnonymizeKeys(keys).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by JSONPath and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(int maxStringLength, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizePaths(expressions).build();
-	}
+// -------------------------------------------------------------------------
+// One-liners: anonymize by JSONPath
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that anonymizes fields by JSONPath, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(int maxStringLength, int maxSize, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizePaths(expressions).build();
-	}
+/**
+ * Create a filter that anonymizes the values at the given JSONPath expressions.
+ *
+ * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(String... expressions) {
+return newBuilder().withAnonymizePaths(expressions).build();
+}
 
-	/**
-	 * Create a filter that removes (prunes) every subtree whose field name matches
-	 * any of the given keys, at any depth in the document.
-	 *
-	 * @param keys one or more bare field names (e.g. {@code "rawPayload"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(String... keys) {
-		return newBuilder().withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes the values at the given JSONPath expressions.
+ *
+ * @param expressions set of JSONPath expressions
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions) {
+return newBuilder().withAnonymizePaths(expressions).build();
+}
 
-	/**
-	 * Create a filter that prunes fields by key name and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(int maxStringLength, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by JSONPath and truncates long strings.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions, int maxStringLength) {
+return newBuilder().withAnonymizePaths(expressions).withMaxStringLength(maxStringLength).build();
+}
 
-	/**
-	 * Create a filter that prunes fields by key name, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(int maxStringLength, int maxSize, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by JSONPath, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions, int maxStringLength, int maxSize) {
+return newBuilder().withAnonymizePaths(expressions).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-	/**
-	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
-	 *
-	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(String... expressions) {
-		return newBuilder().withPrunePaths(expressions).build();
-	}
+// -------------------------------------------------------------------------
+// One-liners: prune by key name
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that prunes by JSONPath and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(int maxStringLength, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withPrunePaths(expressions).build();
-	}
+/**
+ * Create a filter that removes (prunes) every subtree whose field name matches
+ * any of the given keys, at any depth in the document.
+ *
+ * @param keys one or more bare field names (e.g. {@code "appMeta"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(String... keys) {
+return newBuilder().withPruneKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that prunes by JSONPath, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(int maxStringLength, int maxSize, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPrunePaths(expressions).build();
-	}
+/**
+ * Create a filter that removes (prunes) every subtree whose field name matches
+ * any key in the set, at any depth in the document.
+ *
+ * @param keys set of bare field names (e.g. {@code Set.of("appMeta", "diagnostics")})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys) {
+return newBuilder().withPruneKeys(keys).build();
+}
 
-	/**
-	 * @deprecated Use {@link #newBuilder()} instead.
-	 */
-	@Deprecated
-	public static JacksonJsonLogFilterBuilder createInstance() {
-		return new JacksonJsonLogFilterBuilder();
-	}
+/**
+ * Create a filter that prunes fields by key name and truncates long strings.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys, int maxStringLength) {
+return newBuilder().withPruneKeys(keys).withMaxStringLength(maxStringLength).build();
+}
 
-	@Override
-	public JsonFilter build() {
-		JacksonJsonFilterFactory factory = new JacksonJsonFilterFactory();
+/**
+ * Create a filter that prunes fields by key name, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys, int maxStringLength, int maxSize) {
+return newBuilder().withPruneKeys(keys).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-		factory.setMaxStringLength(maxStringLength);
-		factory.setMaxPathMatches(maxPathMatches);
+// -------------------------------------------------------------------------
+// One-liners: prune by JSONPath
+// -------------------------------------------------------------------------
 
-		if(!anonymizeFilters.isEmpty()) {
-			factory.setAnonymize(anonymizeFilters);
-		}
-		if(!pruneFilters.isEmpty()) {
-			factory.setPrune(pruneFilters);
-		}
+/**
+ * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+ *
+ * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.appMeta"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(String... expressions) {
+return newBuilder().withPrunePaths(expressions).build();
+}
 
-		factory.setAnonymizeJsonValue(anonymizeJsonValue);
-		factory.setPruneJsonValue(pruneJsonValue);
-		factory.setTruncateJsonStringValue(truncateStringValue);
+/**
+ * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+ *
+ * @param expressions set of JSONPath expressions
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions) {
+return newBuilder().withPrunePaths(expressions).build();
+}
 
-		factory.setMaxSize(maxSize);
-		factory.setRemoveWhitespace(removeWhitespace);
+/**
+ * Create a filter that prunes by JSONPath and truncates long strings.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions, int maxStringLength) {
+return newBuilder().withPrunePaths(expressions).withMaxStringLength(maxStringLength).build();
+}
 
-		return factory.newJsonFilter();
-	}
+/**
+ * Create a filter that prunes by JSONPath, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions, int maxStringLength, int maxSize) {
+return newBuilder().withPrunePaths(expressions).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
+
+/**
+ * @deprecated Use {@link #newBuilder()} instead.
+ */
+@Deprecated
+public static JacksonJsonLogFilterBuilder createInstance() {
+return new JacksonJsonLogFilterBuilder();
+}
+
+@Override
+public JsonFilter build() {
+JacksonJsonFilterFactory factory = new JacksonJsonFilterFactory();
+
+factory.setMaxStringLength(maxStringLength);
+factory.setMaxPathMatches(maxPathMatches);
+
+if (!anonymizeFilters.isEmpty()) {
+factory.setAnonymize(anonymizeFilters);
+}
+if (!pruneFilters.isEmpty()) {
+factory.setPrune(pruneFilters);
+}
+
+factory.setAnonymizeJsonValue(anonymizeJsonValue);
+factory.setPruneJsonValue(pruneJsonValue);
+factory.setTruncateJsonStringValue(truncateStringValue);
+
+factory.setMaxSize(maxSize);
+factory.setRemoveWhitespace(removeWhitespace);
+
+return factory.newJsonFilter();
+}
 }

--- a/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
+++ b/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
@@ -66,6 +66,30 @@ public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<Ja
 	}
 
 	/**
+	 * Create a filter that anonymizes fields by key name and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(int maxStringLength, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizeKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by key name, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(int maxStringLength, int maxSize, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizeKeys(keys).build();
+	}
+
+	/**
 	 * Create a filter that anonymizes the values at the given JSONPath expressions.
 	 *
 	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
@@ -73,6 +97,30 @@ public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<Ja
 	 */
 	public static JsonFilter anonymizePaths(String... expressions) {
 		return newBuilder().withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by JSONPath and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(int maxStringLength, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by JSONPath, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(int maxStringLength, int maxSize, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizePaths(expressions).build();
 	}
 
 	/**
@@ -87,6 +135,30 @@ public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<Ja
 	}
 
 	/**
+	 * Create a filter that prunes fields by key name and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(int maxStringLength, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withPruneKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that prunes fields by key name, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(int maxStringLength, int maxSize, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPruneKeys(keys).build();
+	}
+
+	/**
 	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
 	 *
 	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
@@ -94,6 +166,30 @@ public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<Ja
 	 */
 	public static JsonFilter prunePaths(String... expressions) {
 		return newBuilder().withPrunePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that prunes by JSONPath and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(int maxStringLength, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withPrunePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that prunes by JSONPath, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(int maxStringLength, int maxSize, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPrunePaths(expressions).build();
 	}
 
 	/**

--- a/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
+++ b/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
@@ -1,128 +1,68 @@
 package com.github.skjolber.jsonfilter.jackson;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.github.skjolber.jsonfilter.JsonFilter;
-import com.github.skjolber.jsonfilter.base.AbstractJsonFilter;
+import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
 
-public class JacksonJsonLogFilterBuilder {
+/**
+ * Fluent builder for a Jackson-backed {@linkplain JsonFilter}.
+ *
+ * <p>The Jackson filter validates document structure during filtering, making it
+ * suitable for untrusted (remotely produced) JSON. For locally produced JSON,
+ * prefer {@code DefaultJsonLogFilterBuilder} for higher throughput.
+ *
+ * <p>All filters produced by this builder are thread-safe and can be reused freely.
+ *
+ * <pre>{@code
+ * JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+ *     .withMaxStringLength(127)
+ *     .withAnonymize("$.customer.email", "$.customer.ssn")
+ *     .withPrune("$.internal.debug")
+ *     .withAnonymizeMessage("[redacted]")
+ *     .build();
+ * }</pre>
+ *
+ * <p>Note: {@code maxPathMatches} is not supported by the Jackson filter and is ignored.
+ */
+public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<JacksonJsonLogFilterBuilder> {
 
+	/**
+	 * Create a new builder instance.
+	 *
+	 * @return a fresh {@linkplain JacksonJsonLogFilterBuilder}
+	 */
+	public static JacksonJsonLogFilterBuilder newBuilder() {
+		return new JacksonJsonLogFilterBuilder();
+	}
+
+	/**
+	 * @deprecated Use {@link #newBuilder()} instead.
+	 */
+	@Deprecated
 	public static JacksonJsonLogFilterBuilder createInstance() {
 		return new JacksonJsonLogFilterBuilder();
 	}
-	
-	protected int maxStringLength = -1;
-	
-	protected List<String> anonymizeFilters = new ArrayList<>();
-	protected List<String> pruneFilters = new ArrayList<>();
 
-	/** Raw JSON */
-	protected String pruneJsonValue;
-	/** Raw JSON */
-	protected String anonymizeJsonValue;
-	
-	/** Raw (escaped) JSON string */
-	protected String truncateStringValue;
-	
+	@Override
 	public JsonFilter build() {
 		JacksonJsonFilterFactory factory = new JacksonJsonFilterFactory();
-		
+
 		factory.setMaxStringLength(maxStringLength);
+		factory.setMaxPathMatches(maxPathMatches);
+
 		if(!anonymizeFilters.isEmpty()) {
 			factory.setAnonymize(anonymizeFilters);
 		}
 		if(!pruneFilters.isEmpty()) {
 			factory.setPrune(pruneFilters);
 		}
-		
+
 		factory.setAnonymizeJsonValue(anonymizeJsonValue);
 		factory.setPruneJsonValue(pruneJsonValue);
 		factory.setTruncateJsonStringValue(truncateStringValue);
 
+		factory.setMaxSize(maxSize);
+		factory.setRemoveWhitespace(removeWhitespace);
+
 		return factory.newJsonFilter();
 	}
-	
-	public JacksonJsonLogFilterBuilder withMaxStringLength(int length) {
-		this.maxStringLength = length;
-		
-		return this;
-	}	
-	
-	public JacksonJsonLogFilterBuilder withPrune(String ... filters) {
-		Collections.addAll(pruneFilters, filters);
-		
-		return this;
-	}
-	
-	public JacksonJsonLogFilterBuilder withAnonymize(String ... filters) {
-		Collections.addAll(anonymizeFilters, filters);
-		return this;
-	}
-		
-	/**
-	 * Set a textual value as use for replacement for pruned value(s)
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-
-	public JacksonJsonLogFilterBuilder withPruneStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		stringBuilder.append('"');
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		stringBuilder.append('"');
-		return withPruneRawJsonValue(stringBuilder.toString());
-	}
-
-	/**
-	 * Set a textual value as use for replacement for anonymized value(s)
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-
-	public JacksonJsonLogFilterBuilder withAnonymizeStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		stringBuilder.append('"');
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		stringBuilder.append('"');
-		return withAnonymizeRawJsonValue(stringBuilder.toString());
-	}
-	
-	/**
-	 * Set the truncate textual value.
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-	
-	public JacksonJsonLogFilterBuilder withTruncateStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		return withTruncateRawJsonStringValue(stringBuilder.toString());
-	}
-	
-	public JacksonJsonLogFilterBuilder withTruncateRawJsonStringValue(String escaped) {
-		this.truncateStringValue = escaped;
-		
-		return this;
-	}
-	
-	public JacksonJsonLogFilterBuilder withPruneRawJsonValue(String raw) {
-		this.pruneJsonValue = raw;
-		
-		return this;
-	}
-
-	public JacksonJsonLogFilterBuilder withAnonymizeRawJsonValue(String raw) {
-		this.anonymizeJsonValue = raw;
-		
-		return this;
-	}	
-	
 }

--- a/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
+++ b/frameworks/jackson/src/main/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilder.java
@@ -12,11 +12,27 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  *
  * <p>All filters produced by this builder are thread-safe and can be reused freely.
  *
+ * <p>Quick one-liner factory methods for the most common cases:
+ * <pre>{@code
+ * // Anonymize fields by name at any depth
+ * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
+ *
+ * // Anonymize fields by precise JSONPath
+ * JsonFilter f = JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+ *
+ * // Remove whole subtrees by name at any depth
+ * JsonFilter f = JacksonJsonLogFilterBuilder.pruneKeys("rawPayload");
+ *
+ * // Remove whole subtrees by precise JSONPath
+ * JsonFilter f = JacksonJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+ * }</pre>
+ *
+ * <p>Use {@link #newBuilder()} for more control:
  * <pre>{@code
  * JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
- *     .withMaxStringLength(127)
- *     .withAnonymize("$.customer.email", "$.customer.ssn")
- *     .withPrune("$.internal.debug")
+ *     .withAnonymizeKeys("password", "ssn")
+ *     .withAnonymizePaths("$.customer.email")
+ *     .withPrunePaths("$.context.rawPayload")
  *     .withAnonymizeMessage("[redacted]")
  *     .build();
  * }</pre>
@@ -32,6 +48,52 @@ public class JacksonJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<Ja
 	 */
 	public static JacksonJsonLogFilterBuilder newBuilder() {
 		return new JacksonJsonLogFilterBuilder();
+	}
+
+	// -------------------------------------------------------------------------
+	// Static one-liner factory methods
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Create a filter that anonymizes every field matching any of the given keys,
+	 * at any depth in the document.
+	 *
+	 * @param keys one or more bare field names (e.g. {@code "password"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(String... keys) {
+		return newBuilder().withAnonymizeKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes the values at the given JSONPath expressions.
+	 *
+	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(String... expressions) {
+		return newBuilder().withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that removes (prunes) every subtree whose field name matches
+	 * any of the given keys, at any depth in the document.
+	 *
+	 * @param keys one or more bare field names (e.g. {@code "rawPayload"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(String... keys) {
+		return newBuilder().withPruneKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+	 *
+	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(String... expressions) {
+		return newBuilder().withPrunePaths(expressions).build();
 	}
 
 	/**

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
@@ -15,8 +15,8 @@ public class JacksonJsonLogFilterBuilderTest {
 	public void testBuilder() {
 		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email")
-				.withPrune("/customer/account")
+				.withAnonymizePaths("/customer/email")
+				.withPrunePaths("/customer/account")
 				.build();
 		assertNotNull(filter);
 	}
@@ -25,7 +25,7 @@ public class JacksonJsonLogFilterBuilderTest {
 	public void testAnonymizeMessage() {
 		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email")
+				.withAnonymizePaths("/customer/email")
 				.withAnonymizeMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
@@ -38,7 +38,7 @@ public class JacksonJsonLogFilterBuilderTest {
 	public void testPruneMessage() {
 		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withPrune("/customer/email")
+				.withPrunePaths("/customer/email")
 				.withPruneMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
@@ -30,7 +30,7 @@ public class JacksonJsonLogFilterBuilderTest {
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"x\\nxxxx\"");
-		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
+		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"[removed]\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
 

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/base/JacksonJsonLogFilterBuilderTest.java
@@ -7,45 +7,44 @@ import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.jsonfilter.JsonFilter;
 import com.github.skjolber.jsonfilter.jackson.JacksonJsonLogFilterBuilder;
-import com.github.skjolber.jsonfilter.jackson.JacksonMaxStringLengthJsonFilter;
-import com.github.skjolber.jsonfilter.jackson.JacksonPathMaxSizeMaxStringLengthJsonFilter;
 import com.github.skjolber.jsonfilter.jackson.JacksonPathMaxStringLengthJsonFilter;
+
 public class JacksonJsonLogFilterBuilderTest {
 
 	@Test
 	public void testBuilder() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.createInstance()
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email") // inserts ***** for values
-				.withPrune("/customer/account") // removes whole subtree
+				.withAnonymize("/customer/email")
+				.withPrune("/customer/account")
 				.build();
 		assertNotNull(filter);
 	}
 
 	@Test
 	public void testAnonymizeMessage() {
-		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.createInstance()
+		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email") // inserts ***** for values
-				.withAnonymizeStringValue("x\nxxxx")
+				.withAnonymize("/customer/email")
+				.withAnonymizeMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"x\\nxxxx\"");
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
-	
+
 	@Test
 	public void testPruneMessage() {
-		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.createInstance()
+		JacksonPathMaxStringLengthJsonFilter filter = (JacksonPathMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withPrune("/customer/email") // inserts ***** for values
-				.withPruneStringValue("x\nxxxx")
+				.withPrune("/customer/email")
+				.withPruneMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"x\\nxxxx\"");
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
-	
+
 }

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
@@ -3,31 +3,68 @@ package com.github.skjolber.jsonfilter.jackson;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.jsonfilter.JsonFilter;
+
 public class JacksonJsonLogFilterBuilderTest {
 
 	@Test
 	public void testBuilder() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.createInstance()
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email") // inserts ***** for values
-				.withPrune("/customer/account") // removes whole subtree
+				.withAnonymize("/customer/email")
+				.withPrune("/customer/account")
 				.build();
 		assertNotNull(filter);
 	}
-	
+
 	@Test
-	public void testTruncateMesseage() {
-		JacksonMaxStringLengthJsonFilter filter = (JacksonMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.createInstance()
+	public void testMultiplePathsVarargs() {
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withAnonymize("$.customer.email", "$.customer.ssn")
+				.withPrune("$.internal.debug", "$.internal.trace")
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testMultiplePathsCollection() {
+		List<String> anonymize = Arrays.asList("$.customer.email", "$.customer.ssn");
+		List<String> prune = Arrays.asList("$.internal.debug", "$.internal.trace");
+
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withAnonymize(anonymize)
+				.withPrune(prune)
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testTruncateMessage() {
+		JacksonMaxStringLengthJsonFilter filter = (JacksonMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withTruncateStringValue("truncated\t")
+				.withTruncateMessage("truncated\t")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 	}
-	
+
+	/** Verify deprecated aliases still work for backwards compatibility. */
+	@Test
+	@SuppressWarnings("deprecation")
+	public void testDeprecatedAliases() {
+		JacksonMaxStringLengthJsonFilter filter = (JacksonMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.createInstance()
+				.withMaxStringLength(127)
+				.withTruncateStringValue("truncated\t")
+				.build();
+		assertNotNull(filter);
+		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
+	}
+
 }

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
@@ -96,8 +96,28 @@ public class JacksonJsonLogFilterBuilderTest {
 	}
 
 	@Test
+	public void testStaticAnonymizeKeysWithMaxStringLength() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn"));
+	}
+
+	@Test
+	public void testStaticAnonymizeKeysWithMaxStringLengthAndMaxSize() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(256, 128 * 1024, "password"));
+	}
+
+	@Test
 	public void testStaticAnonymizePaths() {
 		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email"));
+	}
+
+	@Test
+	public void testStaticAnonymizePathsWithMaxStringLength() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email"));
+	}
+
+	@Test
+	public void testStaticAnonymizePathsWithMaxStringLengthAndMaxSize() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(256, 128 * 1024, "$.customer.email"));
 	}
 
 	@Test
@@ -106,8 +126,28 @@ public class JacksonJsonLogFilterBuilderTest {
 	}
 
 	@Test
+	public void testStaticPruneKeysWithMaxStringLength() {
+		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(256, "rawPayload"));
+	}
+
+	@Test
+	public void testStaticPruneKeysWithMaxStringLengthAndMaxSize() {
+		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(256, 128 * 1024, "rawPayload"));
+	}
+
+	@Test
 	public void testStaticPrunePaths() {
 		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths("$.context.auditLog"));
+	}
+
+	@Test
+	public void testStaticPrunePathsWithMaxStringLength() {
+		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(256, "$.context.auditLog"));
+	}
+
+	@Test
+	public void testStaticPrunePathsWithMaxStringLengthAndMaxSize() {
+		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(256, 128 * 1024, "$.context.auditLog"));
 	}
 
 	@Test

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
@@ -195,7 +195,7 @@ assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta")
 public void testDeprecatedAliases() {
 JsonFilter filter = JacksonJsonLogFilterBuilder.createInstance()
 .withMaxStringLength(127)
-.withPruneStringValue("PRUNED")
+.withPruneStringValue("[removed]")
 .withAnonymizeStringValue("*")
 .withTruncateStringValue("truncated\t")
 .build();

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
@@ -5,173 +5,200 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.skjolber.jsonfilter.JsonFilter;
+import com.github.skjolber.jsonfilter.base.AbstractPathJsonFilter;
 
 public class JacksonJsonLogFilterBuilderTest {
 
-	@Test
-	public void testBuilder() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withMaxStringLength(127)
-				.withAnonymizePaths("/customer/email")
-				.withPrunePaths("/customer/account")
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testBuilder() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withMaxStringLength(127)
+.withAnonymizePaths("/customer/email")
+.withPrunePaths("/customer/account")
+.withPruneMessage("pruneMessage")
+.withAnonymizeMessage("anonymizeMessage")
+.withTruncateMessage("truncateMessage")
+.withMaxSize(32 * 1024)
+.build();
+assertNotNull(filter);
 
-	@Test
-	public void testAnonymizeKeys() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymizeKeys("password", "ssn")
-				.build();
-		assertNotNull(filter);
-	}
+assertThat(filter.getMaxStringLength()).isEqualTo(127);
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"/customer/email"});
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"/customer/account"});
+assertThat(filter.getMaxSize()).isEqualTo(32 * 1024);
+}
 
-	@Test
-	public void testPruneKeys() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withPruneKeys("rawPayload", "auditLog")
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testAnonymizeKeys() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withAnonymizeKeys("password", "ssn")
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+}
 
-	@Test
-	public void testAnonymizeKeysCollection() {
-		List<String> keys = Arrays.asList("password", "ssn");
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymizeKeys(keys)
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testPruneKeys() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withPruneKeys("rawPayload", "auditLog")
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+}
 
-	@Test
-	public void testPruneKeysCollection() {
-		List<String> keys = Arrays.asList("rawPayload", "auditLog");
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withPruneKeys(keys)
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testAnonymizeKeysCollection() {
+List<String> keys = Arrays.asList("password", "ssn");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withAnonymizeKeys(keys)
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+}
 
-	@Test
-	public void testAnonymizePathsVarargs() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymizePaths("$.customer.email", "$.customer.ssn")
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testPruneKeysCollection() {
+List<String> keys = Arrays.asList("rawPayload", "auditLog");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withPruneKeys(keys)
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+}
 
-	@Test
-	public void testPrunePathsVarargs() {
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withPrunePaths("$.internal.debug", "$.internal.trace")
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testAnonymizePathsVarargs() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withAnonymizePaths("$.customer.email", "$.customer.ssn")
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+}
 
-	@Test
-	public void testAnonymizePathsCollection() {
-		List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymizePaths(paths)
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testPrunePathsVarargs() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withPrunePaths("$.internal.debug", "$.internal.trace")
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+}
 
-	@Test
-	public void testPrunePathsCollection() {
-		List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
-		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withPrunePaths(paths)
-				.build();
-		assertNotNull(filter);
-	}
+@Test
+public void testAnonymizePathsCollection() {
+List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withAnonymizePaths(paths)
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+}
 
-	@Test
-	public void testStaticAnonymizeKeys() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys("password", "ssn"));
-	}
+@Test
+public void testPrunePathsCollection() {
+List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
+.withPrunePaths(paths)
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+}
 
-	@Test
-	public void testStaticAnonymizeKeysWithMaxStringLength() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn"));
-	}
+// -------------------------------------------------------------------------
+// Static one-liners: varargs
+// -------------------------------------------------------------------------
 
-	@Test
-	public void testStaticAnonymizeKeysWithMaxStringLengthAndMaxSize() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(256, 128 * 1024, "password"));
-	}
+@Test
+public void testStaticAnonymizeKeysVarargs() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys("password", "ssn"));
+}
 
-	@Test
-	public void testStaticAnonymizePaths() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email"));
-	}
+@Test
+public void testStaticAnonymizePathsVarargs() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email"));
+}
 
-	@Test
-	public void testStaticAnonymizePathsWithMaxStringLength() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email"));
-	}
+@Test
+public void testStaticPruneKeysVarargs() {
+assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys("appMeta"));
+}
 
-	@Test
-	public void testStaticAnonymizePathsWithMaxStringLengthAndMaxSize() {
-		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(256, 128 * 1024, "$.customer.email"));
-	}
+@Test
+public void testStaticPrunePathsVarargs() {
+assertNotNull(JacksonJsonLogFilterBuilder.prunePaths("$.context.appMeta"));
+}
 
-	@Test
-	public void testStaticPruneKeys() {
-		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys("rawPayload"));
-	}
+// -------------------------------------------------------------------------
+// Static one-liners: Set<String>
+// -------------------------------------------------------------------------
 
-	@Test
-	public void testStaticPruneKeysWithMaxStringLength() {
-		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(256, "rawPayload"));
-	}
+@Test
+public void testStaticAnonymizeKeysSet() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn")));
+}
 
-	@Test
-	public void testStaticPruneKeysWithMaxStringLengthAndMaxSize() {
-		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(256, 128 * 1024, "rawPayload"));
-	}
+@Test
+public void testStaticAnonymizeKeysSetWithMaxStringLength() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256));
+}
 
-	@Test
-	public void testStaticPrunePaths() {
-		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths("$.context.auditLog"));
-	}
+@Test
+public void testStaticAnonymizeKeysSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256, 128 * 1024));
+}
 
-	@Test
-	public void testStaticPrunePathsWithMaxStringLength() {
-		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(256, "$.context.auditLog"));
-	}
+@Test
+public void testStaticAnonymizePathsSet() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email")));
+}
 
-	@Test
-	public void testStaticPrunePathsWithMaxStringLengthAndMaxSize() {
-		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(256, 128 * 1024, "$.context.auditLog"));
-	}
+@Test
+public void testStaticAnonymizePathsSetWithMaxStringLength() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email"), 256));
+}
 
-	@Test
-	public void testTruncateMessage() {
-		JacksonMaxStringLengthJsonFilter filter = (JacksonMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.newBuilder()
-				.withMaxStringLength(127)
-				.withTruncateMessage("truncated\t")
-				.build();
-		assertNotNull(filter);
-		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
-		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
-		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
-	}
+@Test
+public void testStaticAnonymizePathsSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email"), 256, 128 * 1024));
+}
 
-	/** Verify deprecated aliases still work for backwards compatibility. */
-	@Test
-	@SuppressWarnings("deprecation")
-	public void testDeprecatedAliases() {
-		JacksonMaxStringLengthJsonFilter filter = (JacksonMaxStringLengthJsonFilter) JacksonJsonLogFilterBuilder.createInstance()
-				.withMaxStringLength(127)
-				.withTruncateStringValue("truncated\t")
-				.build();
-		assertNotNull(filter);
-		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
-	}
+@Test
+public void testStaticPruneKeysSet() {
+assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(Set.of("appMeta")));
+}
 
+@Test
+public void testStaticPruneKeysSetWithMaxStringLength() {
+assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256));
+}
+
+@Test
+public void testStaticPruneKeysSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256, 128 * 1024));
+}
+
+@Test
+public void testStaticPrunePathsSet() {
+assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta")));
+}
+
+@Test
+public void testStaticPrunePathsSetWithMaxStringLength() {
+assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta"), 256));
+}
+
+@Test
+public void testStaticPrunePathsSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(JacksonJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta"), 256, 128 * 1024));
+}
+
+/** Verify deprecated aliases still work for backwards compatibility. */
+@Test
+@SuppressWarnings("deprecation")
+public void testDeprecatedAliases() {
+JsonFilter filter = JacksonJsonLogFilterBuilder.createInstance()
+.withMaxStringLength(127)
+.withPruneStringValue("PRUNED")
+.withAnonymizeStringValue("*")
+.withTruncateStringValue("truncated\t")
+.build();
+assertNotNull(filter);
+}
 }

--- a/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
+++ b/frameworks/jackson/src/test/java/com/github/skjolber/jsonfilter/jackson/JacksonJsonLogFilterBuilderTest.java
@@ -16,31 +16,98 @@ public class JacksonJsonLogFilterBuilderTest {
 	public void testBuilder() {
 		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email")
-				.withPrune("/customer/account")
+				.withAnonymizePaths("/customer/email")
+				.withPrunePaths("/customer/account")
 				.build();
 		assertNotNull(filter);
 	}
 
 	@Test
-	public void testMultiplePathsVarargs() {
+	public void testAnonymizeKeys() {
 		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymize("$.customer.email", "$.customer.ssn")
-				.withPrune("$.internal.debug", "$.internal.trace")
+				.withAnonymizeKeys("password", "ssn")
 				.build();
 		assertNotNull(filter);
 	}
 
 	@Test
-	public void testMultiplePathsCollection() {
-		List<String> anonymize = Arrays.asList("$.customer.email", "$.customer.ssn");
-		List<String> prune = Arrays.asList("$.internal.debug", "$.internal.trace");
-
+	public void testPruneKeys() {
 		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
-				.withAnonymize(anonymize)
-				.withPrune(prune)
+				.withPruneKeys("rawPayload", "auditLog")
 				.build();
 		assertNotNull(filter);
+	}
+
+	@Test
+	public void testAnonymizeKeysCollection() {
+		List<String> keys = Arrays.asList("password", "ssn");
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withAnonymizeKeys(keys)
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testPruneKeysCollection() {
+		List<String> keys = Arrays.asList("rawPayload", "auditLog");
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withPruneKeys(keys)
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testAnonymizePathsVarargs() {
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withAnonymizePaths("$.customer.email", "$.customer.ssn")
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testPrunePathsVarargs() {
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withPrunePaths("$.internal.debug", "$.internal.trace")
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testAnonymizePathsCollection() {
+		List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withAnonymizePaths(paths)
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testPrunePathsCollection() {
+		List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
+		JsonFilter filter = JacksonJsonLogFilterBuilder.newBuilder()
+				.withPrunePaths(paths)
+				.build();
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticAnonymizeKeys() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizeKeys("password", "ssn"));
+	}
+
+	@Test
+	public void testStaticAnonymizePaths() {
+		assertNotNull(JacksonJsonLogFilterBuilder.anonymizePaths("$.customer.email"));
+	}
+
+	@Test
+	public void testStaticPruneKeys() {
+		assertNotNull(JacksonJsonLogFilterBuilder.pruneKeys("rawPayload"));
+	}
+
+	@Test
+	public void testStaticPrunePaths() {
+		assertNotNull(JacksonJsonLogFilterBuilder.prunePaths("$.context.auditLog"));
 	}
 
 	@Test

--- a/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
+++ b/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
@@ -16,41 +16,51 @@
  */
 package com.github.skjolber.jsonfilter.core;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.github.skjolber.jsonfilter.JsonFilter;
-import com.github.skjolber.jsonfilter.base.AbstractJsonFilter;
+import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
 
-public class DefaultJsonLogFilterBuilder {
+/**
+ * Fluent builder for the default (high-performance, non-Jackson) {@linkplain JsonFilter}.
+ *
+ * <p>All filters produced by this builder are thread-safe and can be reused freely.
+ *
+ * <pre>{@code
+ * JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
+ *     .withMaxStringLength(127)
+ *     .withAnonymize("$.customer.email", "$.customer.ssn")
+ *     .withPrune("$.internal.debug", "$.internal.trace")
+ *     .withAnonymizeMessage("[redacted]")
+ *     .withPruneMessage("[removed]")
+ *     .withMaxSize(128 * 1024)
+ *     .build();
+ * }</pre>
+ */
+public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<DefaultJsonLogFilterBuilder> {
 
+	/**
+	 * Create a new builder instance.
+	 *
+	 * @return a fresh {@linkplain DefaultJsonLogFilterBuilder}
+	 */
+	public static DefaultJsonLogFilterBuilder newBuilder() {
+		return new DefaultJsonLogFilterBuilder();
+	}
+
+	/**
+	 * @deprecated Use {@link #newBuilder()} instead.
+	 */
+	@Deprecated
 	public static DefaultJsonLogFilterBuilder createInstance() {
 		return new DefaultJsonLogFilterBuilder();
 	}
-	
-	protected int maxStringLength = -1;
-	protected int maxPathMatches = -1;
-	protected int maxSize = -1;
-	protected boolean removeWhitespace = false;
-	
-	protected List<String> anonymizeFilters = new ArrayList<>();
-	protected List<String> pruneFilters = new ArrayList<>();
-	
-	/** Raw JSON */
-	protected String pruneJsonValue;
-	/** Raw JSON */
-	protected String anonymizeJsonValue;
-	
-	/** Raw (escaped) JSON string */
-	protected String truncateStringValue;
-	
+
+	@Override
 	public JsonFilter build() {
 		DefaultJsonFilterFactory factory = new DefaultJsonFilterFactory();
-		
+
 		factory.setMaxStringLength(maxStringLength);
 		factory.setMaxPathMatches(maxPathMatches);
-		
+
 		factory.setAnonymize(anonymizeFilters);
 		factory.setPrune(pruneFilters);
 
@@ -63,96 +73,4 @@ public class DefaultJsonLogFilterBuilder {
 
 		return factory.newJsonFilter();
 	}
-	
-	public DefaultJsonLogFilterBuilder withMaxSize(int maxSize) {
-		this.maxSize = maxSize;
-		return this;
-	}
-	
-	public DefaultJsonLogFilterBuilder withRemoveWhitespace(boolean removeWhitespace) {
-		this.removeWhitespace = removeWhitespace;
-		return this;
-	}
-	
-	public DefaultJsonLogFilterBuilder withMaxStringLength(int length) {
-		this.maxStringLength = length;
-		return this;
-	}	
-		
-	public DefaultJsonLogFilterBuilder withMaxPathMatches(int length) {
-		this.maxPathMatches = length;
-		return this;
-	}	
-	
-	public DefaultJsonLogFilterBuilder withPrune(String ... filters) {
-		Collections.addAll(pruneFilters, filters);
-		return this;
-	}
-	
-	public DefaultJsonLogFilterBuilder withAnonymize(String ... filters) {
-		Collections.addAll(anonymizeFilters, filters);
-		return this;
-	}
-
-	/**
-	 * Set a textual value as use for replacement for pruned value(s)
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-	
-	public DefaultJsonLogFilterBuilder withPruneStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		stringBuilder.append('"');
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		stringBuilder.append('"');
-		return withPruneRawJsonValue(stringBuilder.toString());
-	}
-	
-	/**
-	 * Set a textual value as use for replacement for anonymized value(s)
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-
-	public DefaultJsonLogFilterBuilder withAnonymizeStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		stringBuilder.append('"');
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		stringBuilder.append('"');
-		return withAnonymizeRawJsonValue(stringBuilder.toString());
-	}
-
-	/**
-	 * Set the truncate textual value.
-	 * 
-	 * @param value the (unescaped) message
-	 * 
-	 * @return this instance
-	 */
-	
-	public DefaultJsonLogFilterBuilder withTruncateStringValue(String value) {
-		StringBuilder stringBuilder = new StringBuilder(value.length() * 2);
-		AbstractJsonFilter.quoteAsString(value, stringBuilder);
-		return withTruncateRawJsonStringValue(stringBuilder.toString());
-	}
-	
-	public DefaultJsonLogFilterBuilder withTruncateRawJsonStringValue(String escaped) {
-		this.truncateStringValue = escaped;
-		return this;
-	}
-	
-	public DefaultJsonLogFilterBuilder withPruneRawJsonValue(String raw) {
-		this.pruneJsonValue = raw;
-		return this;
-	}
-
-	public DefaultJsonLogFilterBuilder withAnonymizeRawJsonValue(String raw) {
-		this.anonymizeJsonValue = raw;
-		return this;
-	}	
-	
 }

--- a/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
+++ b/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
@@ -5,16 +5,18 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	   http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 package com.github.skjolber.jsonfilter.core;
+
+import java.util.Set;
 
 import com.github.skjolber.jsonfilter.JsonFilter;
 import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
@@ -26,17 +28,20 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  *
  * <p>Quick one-liner factory methods for the most common cases:
  * <pre>{@code
- * // Anonymize fields by name at any depth
+ * // Anonymize fields by name at any depth — varargs
  * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
  *
- * // Anonymize fields by precise JSONPath
+ * // Anonymize fields by name — Set with optional size limits
+ * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"));
+ * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256);
+ * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256, 128 * 1024);
+ *
+ * // Anonymize fields by precise JSONPath — varargs
  * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
  *
- * // Remove whole subtrees by name at any depth
- * JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload");
- *
- * // Remove whole subtrees by precise JSONPath
- * JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+ * // Remove whole subtrees by field name — Set with optional size limits
+ * JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta", "diagnostics"));
+ * JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256, 128 * 1024);
  * }</pre>
  *
  * <p>Use {@link #newBuilder()} for more control:
@@ -53,182 +58,236 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  */
 public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<DefaultJsonLogFilterBuilder> {
 
-	/**
-	 * Create a new builder instance.
-	 *
-	 * @return a fresh {@linkplain DefaultJsonLogFilterBuilder}
-	 */
-	public static DefaultJsonLogFilterBuilder newBuilder() {
-		return new DefaultJsonLogFilterBuilder();
-	}
+/**
+ * Create a new builder instance.
+ *
+ * @return a fresh {@linkplain DefaultJsonLogFilterBuilder}
+ */
+public static DefaultJsonLogFilterBuilder newBuilder() {
+return new DefaultJsonLogFilterBuilder();
+}
 
-	// -------------------------------------------------------------------------
-	// Static one-liner factory methods
-	// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
+// One-liners: anonymize by key name
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that anonymizes every field matching any of the given keys,
-	 * at any depth in the document.
-	 *
-	 * @param keys one or more bare field names (e.g. {@code "password"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(String... keys) {
-		return newBuilder().withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes every field matching any of the given keys,
+ * at any depth in the document.
+ *
+ * @param keys one or more bare field names (e.g. {@code "password"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(String... keys) {
+return newBuilder().withAnonymizeKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by key name and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(int maxStringLength, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes every field matching any key in the set,
+ * at any depth in the document.
+ *
+ * @param keys set of bare field names (e.g. {@code Set.of("password", "ssn")})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys) {
+return newBuilder().withAnonymizeKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by key name, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizeKeys(int maxStringLength, int maxSize, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizeKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by key name and truncates long strings.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys, int maxStringLength) {
+return newBuilder().withAnonymizeKeys(keys).withMaxStringLength(maxStringLength).build();
+}
 
-	/**
-	 * Create a filter that anonymizes the values at the given JSONPath expressions.
-	 *
-	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(String... expressions) {
-		return newBuilder().withAnonymizePaths(expressions).build();
-	}
+/**
+ * Create a filter that anonymizes fields by key name, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizeKeys(Set<String> keys, int maxStringLength, int maxSize) {
+return newBuilder().withAnonymizeKeys(keys).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-	/**
-	 * Create a filter that anonymizes fields by JSONPath and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(int maxStringLength, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizePaths(expressions).build();
-	}
+// -------------------------------------------------------------------------
+// One-liners: anonymize by JSONPath
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that anonymizes fields by JSONPath, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter anonymizePaths(int maxStringLength, int maxSize, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizePaths(expressions).build();
-	}
+/**
+ * Create a filter that anonymizes the values at the given JSONPath expressions.
+ *
+ * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(String... expressions) {
+return newBuilder().withAnonymizePaths(expressions).build();
+}
 
-	/**
-	 * Create a filter that removes (prunes) every subtree whose field name matches
-	 * any of the given keys, at any depth in the document.
-	 *
-	 * @param keys one or more bare field names (e.g. {@code "rawPayload"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(String... keys) {
-		return newBuilder().withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes the values at the given JSONPath expressions.
+ *
+ * @param expressions set of JSONPath expressions
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions) {
+return newBuilder().withAnonymizePaths(expressions).build();
+}
 
-	/**
-	 * Create a filter that prunes fields by key name and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(int maxStringLength, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by JSONPath and truncates long strings.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions, int maxStringLength) {
+return newBuilder().withAnonymizePaths(expressions).withMaxStringLength(maxStringLength).build();
+}
 
-	/**
-	 * Create a filter that prunes fields by key name, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param keys            one or more bare field names
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter pruneKeys(int maxStringLength, int maxSize, String... keys) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPruneKeys(keys).build();
-	}
+/**
+ * Create a filter that anonymizes fields by JSONPath, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter anonymizePaths(Set<String> expressions, int maxStringLength, int maxSize) {
+return newBuilder().withAnonymizePaths(expressions).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-	/**
-	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
-	 *
-	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(String... expressions) {
-		return newBuilder().withPrunePaths(expressions).build();
-	}
+// -------------------------------------------------------------------------
+// One-liners: prune by key name
+// -------------------------------------------------------------------------
 
-	/**
-	 * Create a filter that prunes by JSONPath and truncates long strings.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(int maxStringLength, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withPrunePaths(expressions).build();
-	}
+/**
+ * Create a filter that removes (prunes) every subtree whose field name matches
+ * any of the given keys, at any depth in the document.
+ *
+ * @param keys one or more bare field names (e.g. {@code "appMeta"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(String... keys) {
+return newBuilder().withPruneKeys(keys).build();
+}
 
-	/**
-	 * Create a filter that prunes by JSONPath, truncates long strings,
-	 * and limits the total output size.
-	 *
-	 * @param maxStringLength maximum string value length before truncation
-	 * @param maxSize         maximum output document size in bytes
-	 * @param expressions     one or more JSONPath expressions
-	 * @return a ready-to-use, thread-safe filter
-	 */
-	public static JsonFilter prunePaths(int maxStringLength, int maxSize, String... expressions) {
-		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPrunePaths(expressions).build();
-	}
+/**
+ * Create a filter that removes (prunes) every subtree whose field name matches
+ * any key in the set, at any depth in the document.
+ *
+ * @param keys set of bare field names (e.g. {@code Set.of("appMeta", "diagnostics")})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys) {
+return newBuilder().withPruneKeys(keys).build();
+}
 
-	/**
-	 * @deprecated Use {@link #newBuilder()} instead.
-	 */
-	@Deprecated
-	public static DefaultJsonLogFilterBuilder createInstance() {
-		return new DefaultJsonLogFilterBuilder();
-	}
+/**
+ * Create a filter that prunes fields by key name and truncates long strings.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys, int maxStringLength) {
+return newBuilder().withPruneKeys(keys).withMaxStringLength(maxStringLength).build();
+}
 
-	@Override
-	public JsonFilter build() {
-		DefaultJsonFilterFactory factory = new DefaultJsonFilterFactory();
+/**
+ * Create a filter that prunes fields by key name, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param keys            set of bare field names
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter pruneKeys(Set<String> keys, int maxStringLength, int maxSize) {
+return newBuilder().withPruneKeys(keys).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
 
-		factory.setMaxStringLength(maxStringLength);
-		factory.setMaxPathMatches(maxPathMatches);
+// -------------------------------------------------------------------------
+// One-liners: prune by JSONPath
+// -------------------------------------------------------------------------
 
-		factory.setAnonymize(anonymizeFilters);
-		factory.setPrune(pruneFilters);
+/**
+ * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+ *
+ * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.appMeta"})
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(String... expressions) {
+return newBuilder().withPrunePaths(expressions).build();
+}
 
-		factory.setPruneJsonValue(pruneJsonValue);
-		factory.setAnonymizeJsonValue(anonymizeJsonValue);
-		factory.setTruncateJsonStringValue(truncateStringValue);
+/**
+ * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+ *
+ * @param expressions set of JSONPath expressions
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions) {
+return newBuilder().withPrunePaths(expressions).build();
+}
 
-		factory.setMaxSize(maxSize);
-		factory.setRemoveWhitespace(removeWhitespace);
+/**
+ * Create a filter that prunes by JSONPath and truncates long strings.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions, int maxStringLength) {
+return newBuilder().withPrunePaths(expressions).withMaxStringLength(maxStringLength).build();
+}
 
-		return factory.newJsonFilter();
-	}
+/**
+ * Create a filter that prunes by JSONPath, truncates long strings,
+ * and limits the total output size.
+ *
+ * @param expressions     set of JSONPath expressions
+ * @param maxStringLength maximum string value length before truncation
+ * @param maxSize         maximum output document size in bytes
+ * @return a ready-to-use, thread-safe filter
+ */
+public static JsonFilter prunePaths(Set<String> expressions, int maxStringLength, int maxSize) {
+return newBuilder().withPrunePaths(expressions).withMaxStringLength(maxStringLength).withMaxSize(maxSize).build();
+}
+
+/**
+ * @deprecated Use {@link #newBuilder()} instead.
+ */
+@Deprecated
+public static DefaultJsonLogFilterBuilder createInstance() {
+return new DefaultJsonLogFilterBuilder();
+}
+
+@Override
+public JsonFilter build() {
+DefaultJsonFilterFactory factory = new DefaultJsonFilterFactory();
+
+factory.setMaxStringLength(maxStringLength);
+factory.setMaxPathMatches(maxPathMatches);
+
+factory.setAnonymize(anonymizeFilters);
+factory.setPrune(pruneFilters);
+
+factory.setPruneJsonValue(pruneJsonValue);
+factory.setAnonymizeJsonValue(anonymizeJsonValue);
+factory.setTruncateJsonStringValue(truncateStringValue);
+
+factory.setMaxSize(maxSize);
+factory.setRemoveWhitespace(removeWhitespace);
+
+return factory.newJsonFilter();
+}
 }

--- a/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
+++ b/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
@@ -24,13 +24,29 @@ import com.github.skjolber.jsonfilter.base.AbstractJsonLogFilterBuilder;
  *
  * <p>All filters produced by this builder are thread-safe and can be reused freely.
  *
+ * <p>Quick one-liner factory methods for the most common cases:
+ * <pre>{@code
+ * // Anonymize fields by name at any depth
+ * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
+ *
+ * // Anonymize fields by precise JSONPath
+ * JsonFilter f = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+ *
+ * // Remove whole subtrees by name at any depth
+ * JsonFilter f = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload");
+ *
+ * // Remove whole subtrees by precise JSONPath
+ * JsonFilter f = DefaultJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+ * }</pre>
+ *
+ * <p>Use {@link #newBuilder()} for more control:
  * <pre>{@code
  * JsonFilter filter = DefaultJsonLogFilterBuilder.newBuilder()
- *     .withMaxStringLength(127)
- *     .withAnonymize("$.customer.email", "$.customer.ssn")
- *     .withPrune("$.internal.debug", "$.internal.trace")
+ *     .withAnonymizeKeys("password", "ssn")
+ *     .withAnonymizePaths("$.customer.email")
+ *     .withPrunePaths("$.context.rawPayload")
  *     .withAnonymizeMessage("[redacted]")
- *     .withPruneMessage("[removed]")
+ *     .withMaxStringLength(256)
  *     .withMaxSize(128 * 1024)
  *     .build();
  * }</pre>
@@ -44,6 +60,52 @@ public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<De
 	 */
 	public static DefaultJsonLogFilterBuilder newBuilder() {
 		return new DefaultJsonLogFilterBuilder();
+	}
+
+	// -------------------------------------------------------------------------
+	// Static one-liner factory methods
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Create a filter that anonymizes every field matching any of the given keys,
+	 * at any depth in the document.
+	 *
+	 * @param keys one or more bare field names (e.g. {@code "password"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(String... keys) {
+		return newBuilder().withAnonymizeKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes the values at the given JSONPath expressions.
+	 *
+	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(String... expressions) {
+		return newBuilder().withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that removes (prunes) every subtree whose field name matches
+	 * any of the given keys, at any depth in the document.
+	 *
+	 * @param keys one or more bare field names (e.g. {@code "rawPayload"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(String... keys) {
+		return newBuilder().withPruneKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
+	 *
+	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(String... expressions) {
+		return newBuilder().withPrunePaths(expressions).build();
 	}
 
 	/**

--- a/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
+++ b/impl/core/src/main/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilder.java
@@ -78,6 +78,30 @@ public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<De
 	}
 
 	/**
+	 * Create a filter that anonymizes fields by key name and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(int maxStringLength, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizeKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by key name, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizeKeys(int maxStringLength, int maxSize, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizeKeys(keys).build();
+	}
+
+	/**
 	 * Create a filter that anonymizes the values at the given JSONPath expressions.
 	 *
 	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.customer.email"})
@@ -85,6 +109,30 @@ public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<De
 	 */
 	public static JsonFilter anonymizePaths(String... expressions) {
 		return newBuilder().withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by JSONPath and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(int maxStringLength, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withAnonymizePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that anonymizes fields by JSONPath, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter anonymizePaths(int maxStringLength, int maxSize, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withAnonymizePaths(expressions).build();
 	}
 
 	/**
@@ -99,6 +147,30 @@ public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<De
 	}
 
 	/**
+	 * Create a filter that prunes fields by key name and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(int maxStringLength, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withPruneKeys(keys).build();
+	}
+
+	/**
+	 * Create a filter that prunes fields by key name, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param keys            one or more bare field names
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter pruneKeys(int maxStringLength, int maxSize, String... keys) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPruneKeys(keys).build();
+	}
+
+	/**
 	 * Create a filter that removes (prunes) the subtrees at the given JSONPath expressions.
 	 *
 	 * @param expressions one or more JSONPath expressions (e.g. {@code "$.context.auditLog"})
@@ -106,6 +178,30 @@ public class DefaultJsonLogFilterBuilder extends AbstractJsonLogFilterBuilder<De
 	 */
 	public static JsonFilter prunePaths(String... expressions) {
 		return newBuilder().withPrunePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that prunes by JSONPath and truncates long strings.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(int maxStringLength, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withPrunePaths(expressions).build();
+	}
+
+	/**
+	 * Create a filter that prunes by JSONPath, truncates long strings,
+	 * and limits the total output size.
+	 *
+	 * @param maxStringLength maximum string value length before truncation
+	 * @param maxSize         maximum output document size in bytes
+	 * @param expressions     one or more JSONPath expressions
+	 * @return a ready-to-use, thread-safe filter
+	 */
+	public static JsonFilter prunePaths(int maxStringLength, int maxSize, String... expressions) {
+		return newBuilder().withMaxStringLength(maxStringLength).withMaxSize(maxSize).withPrunePaths(expressions).build();
 	}
 
 	/**

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
@@ -13,7 +13,7 @@ public class DefaultJsonLogFilterBuilderTest {
 	@Test
 	public void testAnonymizeMessage() {
 		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymize("/customer/email")
+				.withAnonymizePaths("/customer/email")
 				.withAnonymizeMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
@@ -25,7 +25,7 @@ public class DefaultJsonLogFilterBuilderTest {
 	@Test
 	public void testPruneMessage() {
 		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withPrune("/customer/email")
+				.withPrunePaths("/customer/email")
 				.withPruneMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
@@ -18,7 +18,7 @@ public class DefaultJsonLogFilterBuilderTest {
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"x\\nxxxx\"");
-		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
+		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"[removed]\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
 

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/base/DefaultJsonLogFilterBuilderTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.jsonfilter.base.AbstractJsonFilter;
-import com.github.skjolber.jsonfilter.base.AbstractPathJsonFilter;
 import com.github.skjolber.jsonfilter.core.AbstractRangesPathJsonFilter;
 import com.github.skjolber.jsonfilter.core.DefaultJsonLogFilterBuilder;
 
@@ -14,26 +12,26 @@ public class DefaultJsonLogFilterBuilderTest {
 
 	@Test
 	public void testAnonymizeMessage() {
-		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
-				.withAnonymize("/customer/email") // inserts ***** for values
-				.withAnonymizeStringValue("x\nxxxx")
+		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withAnonymize("/customer/email")
+				.withAnonymizeMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"x\\nxxxx\"");
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
-	
+
 	@Test
 	public void testPruneMessage() {
-		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
-				.withPrune("/customer/email") // inserts ***** for values
-				.withPruneStringValue("x\nxxxx")
+		AbstractRangesPathJsonFilter filter = (AbstractRangesPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withPrune("/customer/email")
+				.withPruneMessage("x\nxxxx")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"x\\nxxxx\"");
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("... + ");
 	}
-	
+
 }

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/ByteArrayRangesFilterTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/ByteArrayRangesFilterTest.java
@@ -251,7 +251,7 @@ public class ByteArrayRangesFilterTest {
 	@Test
 	public void testPruneSubtreeScalar() throws IOException {
 		String[] inputs = new String[]{"\"abcde\",", "\"abcde\"}"};
-		String[] outputs = new String[]{"\"PRUNED\",", "\"PRUNED\"}"};
+		String[] outputs = new String[]{"\"[removed]\",", "\"[removed]\"}"};
 		
 		for(int i = 0; i < inputs.length; i++) {
 			String input = inputs[i];

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/CharArrayRangesFilterTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/CharArrayRangesFilterTest.java
@@ -235,7 +235,7 @@ public class CharArrayRangesFilterTest {
 	@Test
 	public void testPruneSubtreeScalar() throws IOException {
 		String[] inputs = new String[]{"\"abcde\",", "\"abcde\"}"};
-		String[] outputs = new String[]{"\"PRUNED\",", "\"PRUNED\"}"};
+		String[] outputs = new String[]{"\"[removed]\",", "\"[removed]\"}"};
 		
 		for(int i = 0; i < inputs.length; i++) {
 			String input = inputs[i];

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,191 +14,210 @@ import com.github.skjolber.jsonfilter.base.AbstractPathJsonFilter;
 
 public class DefaultJsonLogFilterBuilderTest {
 
-	@Test
-	public void testBuilder() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withMaxStringLength(127)
-				.withAnonymizePaths("/customer/email")
-				.withPrunePaths("/customer/account")
-				.withPruneMessage("pruneMessage")
-				.withAnonymizeMessage("pruneMessage")
-				.withTruncateMessage("truncateMessage")
-				.withMaxPathMatches(10)
-				.withMaxSize(32 * 1024)
-				.build();
-		assertNotNull(filter);
+@Test
+public void testBuilder() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withMaxStringLength(127)
+.withAnonymizePaths("/customer/email")
+.withPrunePaths("/customer/account")
+.withPruneMessage("pruneMessage")
+.withAnonymizeMessage("pruneMessage")
+.withTruncateMessage("truncateMessage")
+.withMaxPathMatches(10)
+.withMaxSize(32 * 1024)
+.build();
+assertNotNull(filter);
 
-		assertThat(filter.getMaxStringLength()).isEqualTo(127);
-		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"/customer/email"});
-		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"/customer/account"});
-		assertThat(filter.getMaxPathMatches()).isEqualTo(10);
-		assertThat(filter.getMaxSize()).isEqualTo(32 * 1024);
-	}
+assertThat(filter.getMaxStringLength()).isEqualTo(127);
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"/customer/email"});
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"/customer/account"});
+assertThat(filter.getMaxPathMatches()).isEqualTo(10);
+assertThat(filter.getMaxSize()).isEqualTo(32 * 1024);
+}
 
-	@Test
-	public void testAnonymizeKeys() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymizeKeys("password", "ssn")
-				.build();
-		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
-	}
+@Test
+public void testAnonymizeKeys() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withAnonymizeKeys("password", "ssn")
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+}
 
-	@Test
-	public void testPruneKeys() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withPruneKeys("rawPayload", "auditLog")
-				.build();
-		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
-	}
+@Test
+public void testPruneKeys() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withPruneKeys("rawPayload", "auditLog")
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+}
 
-	@Test
-	public void testAnonymizeKeysCollection() {
-		List<String> keys = Arrays.asList("password", "ssn");
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymizeKeys(keys)
-				.build();
-		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
-	}
+@Test
+public void testAnonymizeKeysCollection() {
+List<String> keys = Arrays.asList("password", "ssn");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withAnonymizeKeys(keys)
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+}
 
-	@Test
-	public void testPruneKeysCollection() {
-		List<String> keys = Arrays.asList("rawPayload", "auditLog");
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withPruneKeys(keys)
-				.build();
-		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
-	}
+@Test
+public void testPruneKeysCollection() {
+List<String> keys = Arrays.asList("rawPayload", "auditLog");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withPruneKeys(keys)
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+}
 
-	@Test
-	public void testAnonymizePathsVarargs() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymizePaths("$.customer.email", "$.customer.ssn")
-				.build();
-		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
-	}
+@Test
+public void testAnonymizePathsVarargs() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withAnonymizePaths("$.customer.email", "$.customer.ssn")
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+}
 
-	@Test
-	public void testPrunePathsVarargs() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withPrunePaths("$.internal.debug", "$.internal.trace")
-				.build();
-		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
-	}
+@Test
+public void testPrunePathsVarargs() {
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withPrunePaths("$.internal.debug", "$.internal.trace")
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+}
 
-	@Test
-	public void testAnonymizePathsCollection() {
-		List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymizePaths(paths)
-				.build();
-		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
-	}
+@Test
+public void testAnonymizePathsCollection() {
+List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withAnonymizePaths(paths)
+.build();
+assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+}
 
-	@Test
-	public void testPrunePathsCollection() {
-		List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withPrunePaths(paths)
-				.build();
-		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
-	}
+@Test
+public void testPrunePathsCollection() {
+List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
+AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withPrunePaths(paths)
+.build();
+assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+}
 
-	@Test
-	public void testStaticAnonymizeKeys() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
-		assertNotNull(filter);
-	}
+// -------------------------------------------------------------------------
+// Static one-liners: varargs
+// -------------------------------------------------------------------------
 
-	@Test
-	public void testStaticAnonymizeKeysWithMaxStringLength() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizeKeysVarargs() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn"));
+}
 
-	@Test
-	public void testStaticAnonymizeKeysWithMaxStringLengthAndMaxSize() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(256, 128 * 1024, "password");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizePathsVarargs() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email"));
+}
 
-	@Test
-	public void testStaticAnonymizePaths() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticPruneKeysVarargs() {
+assertNotNull(DefaultJsonLogFilterBuilder.pruneKeys("appMeta"));
+}
 
-	@Test
-	public void testStaticAnonymizePathsWithMaxStringLength() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticPrunePathsVarargs() {
+assertNotNull(DefaultJsonLogFilterBuilder.prunePaths("$.context.appMeta"));
+}
 
-	@Test
-	public void testStaticAnonymizePathsWithMaxStringLengthAndMaxSize() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths(256, 128 * 1024, "$.customer.email");
-		assertNotNull(filter);
-	}
+// -------------------------------------------------------------------------
+// Static one-liners: Set<String>
+// -------------------------------------------------------------------------
 
-	@Test
-	public void testStaticPruneKeys() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizeKeysSet() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn")));
+}
 
-	@Test
-	public void testStaticPruneKeysWithMaxStringLength() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys(256, "rawPayload");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizeKeysSetWithMaxStringLength() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256));
+}
 
-	@Test
-	public void testStaticPruneKeysWithMaxStringLengthAndMaxSize() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys(256, 128 * 1024, "rawPayload");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizeKeysSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizeKeys(Set.of("password", "ssn"), 256, 128 * 1024));
+}
 
-	@Test
-	public void testStaticPrunePaths() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths("$.context.auditLog");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizePathsSet() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email")));
+}
 
-	@Test
-	public void testStaticPrunePathsWithMaxStringLength() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths(256, "$.context.auditLog");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizePathsSetWithMaxStringLength() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email"), 256));
+}
 
-	@Test
-	public void testStaticPrunePathsWithMaxStringLengthAndMaxSize() {
-		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths(256, 128 * 1024, "$.context.auditLog");
-		assertNotNull(filter);
-	}
+@Test
+public void testStaticAnonymizePathsSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(DefaultJsonLogFilterBuilder.anonymizePaths(Set.of("$.customer.email"), 256, 128 * 1024));
+}
 
-	@Test
-	public void testTruncateMessage() {
-		MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withMaxStringLength(127)
-				.withTruncateMessage("truncated\t")
-				.build();
-		assertNotNull(filter);
-		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
-		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
-		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
-	}
+@Test
+public void testStaticPruneKeysSet() {
+assertNotNull(DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta")));
+}
 
-	/** Verify deprecated aliases still work for backwards compatibility. */
-	@Test
-	@SuppressWarnings("deprecation")
-	public void testDeprecatedAliases() {
-		MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
-				.withMaxStringLength(127)
-				.withPruneStringValue("PRUNED")
-				.withAnonymizeStringValue("*")
-				.withTruncateStringValue("truncated\t")
-				.build();
-		assertNotNull(filter);
-		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
-	}
+@Test
+public void testStaticPruneKeysSetWithMaxStringLength() {
+assertNotNull(DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256));
+}
 
+@Test
+public void testStaticPruneKeysSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(DefaultJsonLogFilterBuilder.pruneKeys(Set.of("appMeta"), 256, 128 * 1024));
+}
+
+@Test
+public void testStaticPrunePathsSet() {
+assertNotNull(DefaultJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta")));
+}
+
+@Test
+public void testStaticPrunePathsSetWithMaxStringLength() {
+assertNotNull(DefaultJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta"), 256));
+}
+
+@Test
+public void testStaticPrunePathsSetWithMaxStringLengthAndMaxSize() {
+assertNotNull(DefaultJsonLogFilterBuilder.prunePaths(Set.of("$.context.appMeta"), 256, 128 * 1024));
+}
+
+// -------------------------------------------------------------------------
+// Truncate message and deprecated aliases
+// -------------------------------------------------------------------------
+
+@Test
+public void testTruncateMessage() {
+MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+.withMaxStringLength(127)
+.withTruncateMessage("truncated\t")
+.build();
+assertNotNull(filter);
+assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
+assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
+assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
+}
+
+/** Verify deprecated aliases still work for backwards compatibility. */
+@Test
+@SuppressWarnings("deprecation")
+public void testDeprecatedAliases() {
+MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
+.withMaxStringLength(127)
+.withPruneStringValue("PRUNED")
+.withAnonymizeStringValue("*")
+.withTruncateStringValue("truncated\t")
+.build();
+assertNotNull(filter);
+assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
+}
 }

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
@@ -109,8 +109,32 @@ public class DefaultJsonLogFilterBuilderTest {
 	}
 
 	@Test
+	public void testStaticAnonymizeKeysWithMaxStringLength() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(256, "password", "ssn");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticAnonymizeKeysWithMaxStringLengthAndMaxSize() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys(256, 128 * 1024, "password");
+		assertNotNull(filter);
+	}
+
+	@Test
 	public void testStaticAnonymizePaths() {
 		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticAnonymizePathsWithMaxStringLength() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths(256, "$.customer.email");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticAnonymizePathsWithMaxStringLengthAndMaxSize() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths(256, 128 * 1024, "$.customer.email");
 		assertNotNull(filter);
 	}
 
@@ -121,8 +145,32 @@ public class DefaultJsonLogFilterBuilderTest {
 	}
 
 	@Test
+	public void testStaticPruneKeysWithMaxStringLength() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys(256, "rawPayload");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticPruneKeysWithMaxStringLengthAndMaxSize() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys(256, 128 * 1024, "rawPayload");
+		assertNotNull(filter);
+	}
+
+	@Test
 	public void testStaticPrunePaths() {
 		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticPrunePathsWithMaxStringLength() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths(256, "$.context.auditLog");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticPrunePathsWithMaxStringLengthAndMaxSize() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths(256, 128 * 1024, "$.context.auditLog");
 		assertNotNull(filter);
 	}
 

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
@@ -3,44 +3,87 @@ package com.github.skjolber.jsonfilter.core;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-import com.github.skjolber.jsonfilter.base.AbstractJsonFilter;
 import com.github.skjolber.jsonfilter.base.AbstractPathJsonFilter;
 
 public class DefaultJsonLogFilterBuilderTest {
 
 	@Test
 	public void testBuilder() {
-		AbstractPathJsonFilter filter = (AbstractPathJsonFilter)DefaultJsonLogFilterBuilder.createInstance()
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email") // inserts ***** for values
-				.withPrune("/customer/account") // removes whole subtree
-				.withPruneStringValue("pruneMessage")
-				.withAnonymizeStringValue("pruneMessage")
-				.withTruncateStringValue("truncateMessage")
+				.withAnonymize("/customer/email")
+				.withPrune("/customer/account")
+				.withPruneMessage("pruneMessage")
+				.withAnonymizeMessage("pruneMessage")
+				.withTruncateMessage("truncateMessage")
 				.withMaxPathMatches(10)
 				.withMaxSize(32 * 1024)
 				.build();
 		assertNotNull(filter);
-		
+
 		assertThat(filter.getMaxStringLength()).isEqualTo(127);
 		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"/customer/email"});
 		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"/customer/account"});
 		assertThat(filter.getMaxPathMatches()).isEqualTo(10);
 		assertThat(filter.getMaxSize()).isEqualTo(32 * 1024);
 	}
-	
+
+	@Test
+	public void testMultiplePathsVarargs() {
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withAnonymize("$.customer.email", "$.customer.ssn")
+				.withPrune("$.internal.debug", "$.internal.trace")
+				.build();
+		assertNotNull(filter);
+
+		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+	}
+
+	@Test
+	public void testMultiplePathsCollection() {
+		List<String> anonymize = Arrays.asList("$.customer.email", "$.customer.ssn");
+		List<String> prune = Arrays.asList("$.internal.debug", "$.internal.trace");
+
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withAnonymize(anonymize)
+				.withPrune(prune)
+				.build();
+		assertNotNull(filter);
+
+		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+	}
+
 	@Test
 	public void testTruncateMessage() {
-		MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
+		MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withTruncateStringValue("truncated\t")
+				.withTruncateMessage("truncated\t")
 				.build();
 		assertNotNull(filter);
 		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
 		assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
 		assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 	}
-	
+
+	/** Verify deprecated aliases still work for backwards compatibility. */
+	@Test
+	@SuppressWarnings("deprecation")
+	public void testDeprecatedAliases() {
+		MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
+				.withMaxStringLength(127)
+				.withPruneStringValue("PRUNED")
+				.withAnonymizeStringValue("*")
+				.withTruncateStringValue("truncated\t")
+				.build();
+		assertNotNull(filter);
+		assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
+	}
+
 }

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.skjolber.jsonfilter.JsonFilter;
 import com.github.skjolber.jsonfilter.base.AbstractPathJsonFilter;
 
 public class DefaultJsonLogFilterBuilderTest {
@@ -16,8 +17,8 @@ public class DefaultJsonLogFilterBuilderTest {
 	public void testBuilder() {
 		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
 				.withMaxStringLength(127)
-				.withAnonymize("/customer/email")
-				.withPrune("/customer/account")
+				.withAnonymizePaths("/customer/email")
+				.withPrunePaths("/customer/account")
 				.withPruneMessage("pruneMessage")
 				.withAnonymizeMessage("pruneMessage")
 				.withTruncateMessage("truncateMessage")
@@ -34,30 +35,95 @@ public class DefaultJsonLogFilterBuilderTest {
 	}
 
 	@Test
-	public void testMultiplePathsVarargs() {
+	public void testAnonymizeKeys() {
 		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymize("$.customer.email", "$.customer.ssn")
-				.withPrune("$.internal.debug", "$.internal.trace")
+				.withAnonymizeKeys("password", "ssn")
 				.build();
-		assertNotNull(filter);
+		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+	}
 
+	@Test
+	public void testPruneKeys() {
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withPruneKeys("rawPayload", "auditLog")
+				.build();
+		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+	}
+
+	@Test
+	public void testAnonymizeKeysCollection() {
+		List<String> keys = Arrays.asList("password", "ssn");
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withAnonymizeKeys(keys)
+				.build();
+		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$..password", "$..ssn"});
+	}
+
+	@Test
+	public void testPruneKeysCollection() {
+		List<String> keys = Arrays.asList("rawPayload", "auditLog");
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withPruneKeys(keys)
+				.build();
+		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$..rawPayload", "$..auditLog"});
+	}
+
+	@Test
+	public void testAnonymizePathsVarargs() {
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withAnonymizePaths("$.customer.email", "$.customer.ssn")
+				.build();
 		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+	}
+
+	@Test
+	public void testPrunePathsVarargs() {
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withPrunePaths("$.internal.debug", "$.internal.trace")
+				.build();
 		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
 	}
 
 	@Test
-	public void testMultiplePathsCollection() {
-		List<String> anonymize = Arrays.asList("$.customer.email", "$.customer.ssn");
-		List<String> prune = Arrays.asList("$.internal.debug", "$.internal.trace");
-
+	public void testAnonymizePathsCollection() {
+		List<String> paths = Arrays.asList("$.customer.email", "$.customer.ssn");
 		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
-				.withAnonymize(anonymize)
-				.withPrune(prune)
+				.withAnonymizePaths(paths)
 				.build();
-		assertNotNull(filter);
-
 		assertThat(filter.getAnonymizeFilters()).isEqualTo(new String[]{"$.customer.email", "$.customer.ssn"});
+	}
+
+	@Test
+	public void testPrunePathsCollection() {
+		List<String> paths = Arrays.asList("$.internal.debug", "$.internal.trace");
+		AbstractPathJsonFilter filter = (AbstractPathJsonFilter) DefaultJsonLogFilterBuilder.newBuilder()
+				.withPrunePaths(paths)
+				.build();
 		assertThat(filter.getPruneFilters()).isEqualTo(new String[]{"$.internal.debug", "$.internal.trace"});
+	}
+
+	@Test
+	public void testStaticAnonymizeKeys() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizeKeys("password", "ssn");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticAnonymizePaths() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.anonymizePaths("$.customer.email");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticPruneKeys() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.pruneKeys("rawPayload");
+		assertNotNull(filter);
+	}
+
+	@Test
+	public void testStaticPrunePaths() {
+		JsonFilter filter = DefaultJsonLogFilterBuilder.prunePaths("$.context.auditLog");
+		assertNotNull(filter);
 	}
 
 	@Test

--- a/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
+++ b/impl/core/src/test/java/com/github/skjolber/jsonfilter/core/DefaultJsonLogFilterBuilderTest.java
@@ -203,7 +203,7 @@ MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFil
 .build();
 assertNotNull(filter);
 assertThat(new String(filter.getTruncateStringValue())).isEqualTo("truncated\\t");
-assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"PRUNED\"");
+assertThat(new String(filter.getPruneJsonValue())).isEqualTo("\"[removed]\"");
 assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 }
 
@@ -213,7 +213,7 @@ assertThat(new String(filter.getAnonymizeJsonValue())).isEqualTo("\"*\"");
 public void testDeprecatedAliases() {
 MaxStringLengthJsonFilter filter = (MaxStringLengthJsonFilter) DefaultJsonLogFilterBuilder.createInstance()
 .withMaxStringLength(127)
-.withPruneStringValue("PRUNED")
+.withPruneStringValue("[removed]")
 .withAnonymizeStringValue("*")
 .withTruncateStringValue("truncated\t")
 .build();

--- a/support/test/src/main/java/com/github/skjolber/jsonfilter/test/JsonPathFilter.java
+++ b/support/test/src/main/java/com/github/skjolber/jsonfilter/test/JsonPathFilter.java
@@ -28,7 +28,7 @@ public class JsonPathFilter implements JsonFilter {
 
 	private static JsonPath ANY = JsonPath.compile("$..*");
 	
-	public static final String FILTER_PRUNE_MESSAGE = "PRUNED";
+	public static final String FILTER_PRUNE_MESSAGE = "[removed]";
 	public static final String FILTER_ANONYMIZE = "*";
 	public static final String FILTER_TRUNCATE_MESSAGE = "... + ";
 	

--- a/support/test/src/main/resources/json/array/1d/prune/anyArray.json
+++ b/support/test/src/main/resources/json/array/1d/prune/anyArray.json
@@ -1,1 +1,1 @@
-[123,"abc",{"key":"PRUNED"},["aaaaa","bbbbbb","cccccccc"]]
+[123,"abc",{"key":"[removed]"},["aaaaa","bbbbbb","cccccccc"]]

--- a/support/test/src/main/resources/json/array/1d/prune/objectValueNumberArray.json
+++ b/support/test/src/main/resources/json/array/1d/prune/objectValueNumberArray.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/array/1d/prune/objectValueTextArray.json
+++ b/support/test/src/main/resources/json/array/1d/prune/objectValueTextArray.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/array/1d/pruneWildcard/anyArray.json
+++ b/support/test/src/main/resources/json/array/1d/pruneWildcard/anyArray.json
@@ -1,1 +1,1 @@
-[123,"abc",{"key":"PRUNED"},["aaaaa","bbbbbb","cccccccc"]]
+[123,"abc",{"key":"[removed]"},["aaaaa","bbbbbb","cccccccc"]]

--- a/support/test/src/main/resources/json/array/1d/pruneWildcard/objectValueNumberArray.json
+++ b/support/test/src/main/resources/json/array/1d/pruneWildcard/objectValueNumberArray.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/array/1d/pruneWildcard/objectValueTextArray.json
+++ b/support/test/src/main/resources/json/array/1d/pruneWildcard/objectValueTextArray.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/array/2d/prune/arrayObjectArrayKey.json
+++ b/support/test/src/main/resources/json/array/2d/prune/arrayObjectArrayKey.json
@@ -1,1 +1,1 @@
-[{"key":"PRUNED"}]
+[{"key":"[removed]"}]

--- a/support/test/src/main/resources/json/array/2d/prune/objectArrayObjectKey.json
+++ b/support/test/src/main/resources/json/array/2d/prune/objectArrayObjectKey.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/array/prune/anyMaxPathMatches1/array2xObject3xArrayKeyMiddle.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/anyMaxPathMatches1/array2xObject3xArrayKeyMiddle.json
@@ -1,1 +1,1 @@
-[{"before":true,"key":"PRUNED","after":false},{"start":true,"key":true,"end":false}]
+[{"before":true,"key":"[removed]","after":false},{"start":true,"key":true,"end":false}]

--- a/support/test/src/main/resources/json/boolean/array/prune/array2xObject3xArrayKeyMiddle.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/array2xObject3xArrayKeyMiddle.json
@@ -1,1 +1,1 @@
-[{"before":true,"key":"PRUNED","after":false},{"start":true,"key":"PRUNED","end":false}]
+[{"before":true,"key":"[removed]","after":false},{"start":true,"key":"[removed]","end":false}]

--- a/support/test/src/main/resources/json/boolean/array/prune/object1xFalseArrayKey.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/object1xFalseArrayKey.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/array/prune/object1xTrueArrayKey.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/object1xTrueArrayKey.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/array/prune/object2xArrayKeyAfter.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/object2xArrayKeyAfter.json
@@ -1,1 +1,1 @@
-{"first":[false,false,true],"key":"PRUNED"}
+{"first":[false,false,true],"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/array/prune/object2xArrayKeyBefore.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/object2xArrayKeyBefore.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":[false]}
+{"key":"[removed]","after":[false]}

--- a/support/test/src/main/resources/json/boolean/array/prune/object3xArrayKeyMiddle.json
+++ b/support/test/src/main/resources/json/boolean/array/prune/object3xArrayKeyMiddle.json
@@ -1,1 +1,1 @@
-{"first":[false,true,false],"key":"PRUNED","after":[true,false,true]}
+{"first":[false,true,false],"key":"[removed]","after":[true,false,true]}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyAfter1.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyAfter1.json
@@ -1,1 +1,1 @@
-{"after":[false,false,true],"key":"PRUNED"}
+{"after":[false,false,true],"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyAfter2.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyAfter2.json
@@ -1,1 +1,1 @@
-{"after":true,"key":"PRUNED"}
+{"after":true,"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyBefore1.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyBefore1.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":[false]}
+{"key":"[removed]","after":[false]}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyBefore2.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object2xArrayKeyBefore2.json
@@ -1,1 +1,1 @@
-{"first":true,"key":"PRUNED"}
+{"first":true,"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object3xArrayKeyMiddle1.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object3xArrayKeyMiddle1.json
@@ -1,1 +1,1 @@
-{"first":[false,true,false],"key":"PRUNED","after":[true,false,true]}
+{"first":[false,true,false],"key":"[removed]","after":[true,false,true]}

--- a/support/test/src/main/resources/json/boolean/mixed/prune/object3xArrayKeyMiddle2.json
+++ b/support/test/src/main/resources/json/boolean/mixed/prune/object3xArrayKeyMiddle2.json
@@ -1,1 +1,1 @@
-{"first":true,"key":"PRUNED","after":false}
+{"first":true,"key":"[removed]","after":false}

--- a/support/test/src/main/resources/json/boolean/plain/prune/object1xKeyFalse.json
+++ b/support/test/src/main/resources/json/boolean/plain/prune/object1xKeyFalse.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/prune/object1xKeyTrue.json
+++ b/support/test/src/main/resources/json/boolean/plain/prune/object1xKeyTrue.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/prune/object2xKeyAfter.json
+++ b/support/test/src/main/resources/json/boolean/plain/prune/object2xKeyAfter.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED"}
+{"first":false,"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/prune/object2xKeyBefore.json
+++ b/support/test/src/main/resources/json/boolean/plain/prune/object2xKeyBefore.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":true}
+{"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/boolean/plain/prune/object3xKeyMiddle.json
+++ b/support/test/src/main/resources/json/boolean/plain/prune/object3xKeyMiddle.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED","after":true}
+{"first":false,"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/boolean/plain/pruneAny/object1xKeyFalse.json
+++ b/support/test/src/main/resources/json/boolean/plain/pruneAny/object1xKeyFalse.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/pruneAny/object1xKeyTrue.json
+++ b/support/test/src/main/resources/json/boolean/plain/pruneAny/object1xKeyTrue.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/pruneAny/object2xKeyAfter.json
+++ b/support/test/src/main/resources/json/boolean/plain/pruneAny/object2xKeyAfter.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED"}
+{"first":false,"key":"[removed]"}

--- a/support/test/src/main/resources/json/boolean/plain/pruneAny/object2xKeyBefore.json
+++ b/support/test/src/main/resources/json/boolean/plain/pruneAny/object2xKeyBefore.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":true}
+{"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/boolean/plain/pruneAny/object3xKeyMiddle.json
+++ b/support/test/src/main/resources/json/boolean/plain/pruneAny/object3xKeyMiddle.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED","after":true}
+{"first":false,"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/number/plain/prune/object1xKeyFalse.json
+++ b/support/test/src/main/resources/json/number/plain/prune/object1xKeyFalse.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/number/plain/prune/object1xKeyTrue.json
+++ b/support/test/src/main/resources/json/number/plain/prune/object1xKeyTrue.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/number/plain/prune/object2xKeyAfter.json
+++ b/support/test/src/main/resources/json/number/plain/prune/object2xKeyAfter.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED"}
+{"first":false,"key":"[removed]"}

--- a/support/test/src/main/resources/json/number/plain/prune/object2xKeyBefore.json
+++ b/support/test/src/main/resources/json/number/plain/prune/object2xKeyBefore.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":true}
+{"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/number/plain/prune/object3xKeyMiddle.json
+++ b/support/test/src/main/resources/json/number/plain/prune/object3xKeyMiddle.json
@@ -1,1 +1,1 @@
-{"first":false,"key":"PRUNED","after":true}
+{"first":false,"key":"[removed]","after":true}

--- a/support/test/src/main/resources/json/object/all/object1.json
+++ b/support/test/src/main/resources/json/object/all/object1.json
@@ -1,1 +1,1 @@
-{"grandparent":{"parent":{"child1":"*","child2":true,"child3":"PRUNED"}}}
+{"grandparent":{"parent":{"child1":"*","child2":true,"child3":"[removed]"}}}

--- a/support/test/src/main/resources/json/object/all/objectBefore.json
+++ b/support/test/src/main/resources/json/object/all/objectBefore.json
@@ -1,1 +1,1 @@
-{"before":{"parent":{"child1":"text","child2":true,"child3":{"key":"value"}}},"grandparent":{"parent":{"child1":"*","child2":true,"child3":"PRUNED"}}}
+{"before":{"parent":{"child1":"text","child2":true,"child3":{"key":"value"}}},"grandparent":{"parent":{"child1":"*","child2":true,"child3":"[removed]"}}}

--- a/support/test/src/main/resources/json/object/all/objectSibling.json
+++ b/support/test/src/main/resources/json/object/all/objectSibling.json
@@ -1,1 +1,1 @@
-{"grandparent":{"parent":{"child1":"*","child2":true,"child3":"PRUNED"},"parentSibling":{"child1":"text","child2":true,"child3":"child3"}}}
+{"grandparent":{"parent":{"child1":"*","child2":true,"child3":"[removed]"},"parentSibling":{"child1":"text","child2":true,"child3":"child3"}}}

--- a/support/test/src/main/resources/json/object/prune/object1.json
+++ b/support/test/src/main/resources/json/object/prune/object1.json
@@ -1,1 +1,1 @@
-{"grandparent":{"parent":{"child1":"text","child2":true,"child3":"PRUNED"}}}
+{"grandparent":{"parent":{"child1":"text","child2":true,"child3":"[removed]"}}}

--- a/support/test/src/main/resources/json/object/prune/objectBefore.json
+++ b/support/test/src/main/resources/json/object/prune/objectBefore.json
@@ -1,1 +1,1 @@
-{"before":{"parent":{"child1":"text","child2":true,"child3":{"key":"value"}}},"grandparent":{"parent":{"child1":"text","child2":true,"child3":"PRUNED"}}}
+{"before":{"parent":{"child1":"text","child2":true,"child3":{"key":"value"}}},"grandparent":{"parent":{"child1":"text","child2":true,"child3":"[removed]"}}}

--- a/support/test/src/main/resources/json/object/prune/objectSibling.json
+++ b/support/test/src/main/resources/json/object/prune/objectSibling.json
@@ -1,1 +1,1 @@
-{"grandparent":{"parent":{"child1":"text","child2":true,"child3":"PRUNED"},"parentSibling":{"child1":"text","child2":true,"child3":"child3"}}}
+{"grandparent":{"parent":{"child1":"text","child2":true,"child3":"[removed]"},"parentSibling":{"child1":"text","child2":true,"child3":"child3"}}}

--- a/support/test/src/main/resources/json/text/multiple/anonPruneMaxStringLength/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/anonPruneMaxStringLength/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"*","key2":"abcde... + 31","key3":"PRUNED"}
+{"key1":"*","key2":"abcde... + 31","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/anonPruneMaxStringLengthMaxPathMatches/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/anonPruneMaxStringLengthMaxPathMatches/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"*","key2":"abcde... + 31","key3":"PRUNED"}
+{"key1":"*","key2":"abcde... + 31","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/anonymizePrune/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/anonymizePrune/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"*","key2":"abcdefghijklmnopqrstuvwxyz0123456789","key3":"PRUNED"}
+{"key1":"*","key2":"abcdefghijklmnopqrstuvwxyz0123456789","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/pruneMaxPathMatches/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/pruneMaxPathMatches/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"aa","key2":"abcdefghijklmnopqrstuvwxyz0123456789","key3":"PRUNED"}
+{"key1":"aa","key2":"abcdefghijklmnopqrstuvwxyz0123456789","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"aa","key2":"abcde... + 31","key3":"PRUNED"}
+{"key1":"aa","key2":"abcde... + 31","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength1MaxPathMatches/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength1MaxPathMatches/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"aa","key2":"abcde... + 31","key3":"PRUNED"}
+{"key1":"aa","key2":"abcde... + 31","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength2MaxPathMatches/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/multiple/pruneMaxStringLength2MaxPathMatches/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"key1":"PRUNED","key2":"abcde... + 31","key3":"PRUNED"}
+{"key1":"[removed]","key2":"abcde... + 31","key3":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeep.json
+++ b/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeep.json
@@ -1,1 +1,1 @@
-{"a":{"b":{"key":"PRUNED"}}}
+{"a":{"b":{"key":"[removed]"}}}

--- a/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeepEscaped.json
+++ b/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeepEscaped.json
@@ -1,1 +1,1 @@
-{"a":{"b":{"key":"PRUNED"}}}
+{"a":{"b":{"key":"[removed]"}}}

--- a/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeepWithArray.json
+++ b/support/test/src/main/resources/json/text/single/prune/any/object1xKeyDeepWithArray.json
@@ -1,1 +1,1 @@
-{"a":{"b":{"key":"PRUNED"}}}
+{"a":{"b":{"key":"[removed]"}}}

--- a/support/test/src/main/resources/json/text/single/prune/maxStringLength/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/single/prune/maxStringLength/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"first":"aa","key":"PRUNED","after":"abcde... + 31"}
+{"first":"aa","key":"[removed]","after":"abcde... + 31"}

--- a/support/test/src/main/resources/json/text/single/prune/maxStringLength/object3xKeyMiddleShort.json
+++ b/support/test/src/main/resources/json/text/single/prune/maxStringLength/object3xKeyMiddleShort.json
@@ -1,1 +1,1 @@
-{"first":"aa","key":"PRUNED","after":"abcde... + 31"}
+{"first":"aa","key":"[removed]","after":"abcde... + 31"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyEmpty.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyEmpty.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyEscaped.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyEscaped.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyLong.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyLong.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyLongEscaped.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyLongEscaped.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyLongEscapedUnicode.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyLongEscapedUnicode.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyOtherUnicodePlane.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyOtherUnicodePlane.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object1xKeyShort.json
+++ b/support/test/src/main/resources/json/text/single/prune/object1xKeyShort.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED"}
+{"key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object2xKeyAfterLong.json
+++ b/support/test/src/main/resources/json/text/single/prune/object2xKeyAfterLong.json
@@ -1,1 +1,1 @@
-{"first":"value","key":"PRUNED"}
+{"first":"value","key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object2xKeyAfterShort.json
+++ b/support/test/src/main/resources/json/text/single/prune/object2xKeyAfterShort.json
@@ -1,1 +1,1 @@
-{"first":"value","key":"PRUNED"}
+{"first":"value","key":"[removed]"}

--- a/support/test/src/main/resources/json/text/single/prune/object2xKeyBeforeLong.json
+++ b/support/test/src/main/resources/json/text/single/prune/object2xKeyBeforeLong.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":"aaaaa"}
+{"key":"[removed]","after":"aaaaa"}

--- a/support/test/src/main/resources/json/text/single/prune/object2xKeyBeforeShort.json
+++ b/support/test/src/main/resources/json/text/single/prune/object2xKeyBeforeShort.json
@@ -1,1 +1,1 @@
-{"key":"PRUNED","after":"aaaaa"}
+{"key":"[removed]","after":"aaaaa"}

--- a/support/test/src/main/resources/json/text/single/prune/object3xKeyMiddleLong.json
+++ b/support/test/src/main/resources/json/text/single/prune/object3xKeyMiddleLong.json
@@ -1,1 +1,1 @@
-{"first":"aa","key":"PRUNED","after":"abcdefghijklmnopqrstuvwxyz0123456789"}
+{"first":"aa","key":"[removed]","after":"abcdefghijklmnopqrstuvwxyz0123456789"}

--- a/support/test/src/main/resources/json/text/single/prune/object3xKeyMiddleShort.json
+++ b/support/test/src/main/resources/json/text/single/prune/object3xKeyMiddleShort.json
@@ -1,1 +1,1 @@
-{"first":"aa","key":"PRUNED","after":"abcdefghijklmnopqrstuvwxyz0123456789"}
+{"first":"aa","key":"[removed]","after":"abcdefghijklmnopqrstuvwxyz0123456789"}


### PR DESCRIPTION
## Summary

Inspired by the clean API of [json-masker](https://github.com/Breus/json-masker), this PR makes the builder API easier to use and the README much easier to follow.

## Builder changes

### New `AbstractJsonLogFilterBuilder<B>`
Both `DefaultJsonLogFilterBuilder` and `JacksonJsonLogFilterBuilder` previously duplicated all their fields and methods. They now share a single generic base class, with the concrete builders only supplying `build()`.

### `Collection<String>` overloads for path filters
Any `Collection<String>` (List, Set, …) can now be passed directly:
```java
Set<String> sensitiveFields = loadFromConfig();
filter = DefaultJsonLogFilterBuilder.newBuilder()
    .withAnonymize(sensitiveFields)
    .build();
```

### Cleaner output-customization methods
| Old (deprecated) | New |
|---|---|
| `withPruneStringValue(s)` | `withPruneMessage(s)` |
| `withAnonymizeStringValue(s)` | `withAnonymizeMessage(s)` |
| `withTruncateStringValue(s)` | `withTruncateMessage(s)` |

Old names are kept as `@Deprecated` aliases — no breaking changes.

### `newBuilder()` factory method
`createInstance()` is deprecated in favour of the more idiomatic `newBuilder()`.

### `JacksonJsonLogFilterBuilder` gains missing setters
`withMaxSize`, `withMaxPathMatches`, and `withRemoveWhitespace` were present on the default builder but missing from the Jackson one. They are now available on both.

Various README changes.

Change default prune message to "[removed]"
