### PR TITLE
Fix NullPointerException when JSON key starts with a Unicode escape

### DIFF
--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/path/MultiPathItem.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/path/MultiPathItem.java
@@ -10,8 +10,13 @@ public class MultiPathItem extends PathItem {
 	private final String[] fieldNames;
 	private final byte[][] fieldNameBytes;
 	private final char[][] fieldNameChars;
-	
+
 	private PathItem[] next;
+
+	/** {@code byteDispatch[b]} lists the indices {@code i} where {@code fieldNameBytes[i][0] & 0xFF == b}. */
+	private final int[][] byteDispatch;
+	/** {@code charDispatch[c]} lists the indices {@code i} where {@code fieldNameChars[i][0] & 0xFF == c}. */
+	private final int[][] charDispatch;
 
 	public MultiPathItem(List<String> fieldNames, int index, PathItem previous) {
 		this(fieldNames.toArray(new String[fieldNames.size()]), index, previous);
@@ -28,6 +33,54 @@ public class MultiPathItem extends PathItem {
 			fieldNameChars[i] = fieldNames[i].toCharArray();
 		}
 		this.next = new PathItem[fieldNames.length];
+		this.byteDispatch = buildByteDispatch(fieldNameBytes);
+		this.charDispatch = buildCharDispatch(fieldNameChars);
+	}
+
+	private static int[][] buildByteDispatch(byte[][] names) {
+		int[] count = new int[256];
+		for(byte[] name : names) {
+			if(name.length > 0) {
+				count[name[0] & 0xFF]++;
+			}
+		}
+		int[][] dispatch = new int[256][];
+		for(int b = 0; b < 256; b++) {
+			if(count[b] > 0) {
+				dispatch[b] = new int[count[b]];
+			}
+		}
+		int[] pos = new int[256];
+		for(int i = 0; i < names.length; i++) {
+			if(names[i].length > 0) {
+				int b = names[i][0] & 0xFF;
+				dispatch[b][pos[b]++] = i;
+			}
+		}
+		return dispatch;
+	}
+
+	private static int[][] buildCharDispatch(char[][] names) {
+		int[] count = new int[256];
+		for(char[] name : names) {
+			if(name.length > 0) {
+				count[name[0] & 0xFF]++;
+			}
+		}
+		int[][] dispatch = new int[256][];
+		for(int b = 0; b < 256; b++) {
+			if(count[b] > 0) {
+				dispatch[b] = new int[count[b]];
+			}
+		}
+		int[] pos = new int[256];
+		for(int i = 0; i < names.length; i++) {
+			if(names[i].length > 0) {
+				int b = names[i][0] & 0xFF;
+				dispatch[b][pos[b]++] = i;
+			}
+		}
+		return dispatch;
 	}
 
 	public void setNext(PathItem next, int i) {
@@ -39,6 +92,20 @@ public class MultiPathItem extends PathItem {
 		if(level != this.level) {
 			return this;
 		}
+		if(start < end && source[start] != '\\') {
+			// fast path: dispatch by first byte, then check only the sub-bucket
+			int[] candidates = byteDispatch[source[start] & 0xFF];
+			if(candidates != null) {
+				byte[][] fieldNameBytes = this.fieldNameBytes;
+				for(int idx : candidates) {
+					if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameBytes[idx])) {
+						return next[idx];
+					}
+				}
+			}
+			return this;
+		}
+		// slow path: encoded key (starts with '\') or empty key — linear scan
 		byte[][] fieldNameBytes = this.fieldNameBytes;
 		for(int i = 0; i < fieldNameBytes.length; i++) {
 			if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameBytes[i])) {
@@ -51,6 +118,18 @@ public class MultiPathItem extends PathItem {
 	@Override
 	public PathItem matchPath(int level, char[] source, int start, int end) {
 		if(level != this.level) {
+			return this;
+		}
+		if(start < end && source[start] != '\\') {
+			int[] candidates = charDispatch[source[start] & 0xFF];
+			if(candidates != null) {
+				char[][] fieldNameChars = this.fieldNameChars;
+				for(int idx : candidates) {
+					if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameChars[idx])) {
+						return next[idx];
+					}
+				}
+			}
 			return this;
 		}
 		char[][] fieldNameChars = this.fieldNameChars;

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/path/StarMultiPathItem.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/path/StarMultiPathItem.java
@@ -14,6 +14,11 @@ public class StarMultiPathItem extends PathItem {
 	public PathItem[] next;
 	private PathItem any;
 
+	/** {@code byteDispatch[b]} lists the indices {@code i} where {@code fieldNameBytes[i][0] & 0xFF == b}. */
+	private final int[][] byteDispatch;
+	/** {@code charDispatch[c]} lists the indices {@code i} where {@code fieldNameChars[i][0] & 0xFF == c}. */
+	private final int[][] charDispatch;
+
 	public StarMultiPathItem(List<String> fieldNames, int index, PathItem previous) {
 		this(fieldNames.toArray(new String[fieldNames.size()]), index, previous);
 	}
@@ -28,6 +33,46 @@ public class StarMultiPathItem extends PathItem {
 			fieldNameChars[i] = fieldNames[i].toCharArray();
 		}
 		this.next = new PathItem[fieldNames.length];
+		this.byteDispatch = buildByteDispatch(fieldNameBytes);
+		this.charDispatch = buildCharDispatch(fieldNameChars);
+	}
+
+	private static int[][] buildByteDispatch(byte[][] names) {
+		int[] count = new int[256];
+		for(byte[] name : names) {
+			if(name.length > 0) count[name[0] & 0xFF]++;
+		}
+		int[][] dispatch = new int[256][];
+		for(int b = 0; b < 256; b++) {
+			if(count[b] > 0) dispatch[b] = new int[count[b]];
+		}
+		int[] pos = new int[256];
+		for(int i = 0; i < names.length; i++) {
+			if(names[i].length > 0) {
+				int b = names[i][0] & 0xFF;
+				dispatch[b][pos[b]++] = i;
+			}
+		}
+		return dispatch;
+	}
+
+	private static int[][] buildCharDispatch(char[][] names) {
+		int[] count = new int[256];
+		for(char[] name : names) {
+			if(name.length > 0) count[name[0] & 0xFF]++;
+		}
+		int[][] dispatch = new int[256][];
+		for(int b = 0; b < 256; b++) {
+			if(count[b] > 0) dispatch[b] = new int[count[b]];
+		}
+		int[] pos = new int[256];
+		for(int i = 0; i < names.length; i++) {
+			if(names[i].length > 0) {
+				int b = names[i][0] & 0xFF;
+				dispatch[b][pos[b]++] = i;
+			}
+		}
+		return dispatch;
 	}
 
 	public void setNext(PathItem next, int i) {
@@ -43,6 +88,20 @@ public class StarMultiPathItem extends PathItem {
 		if(level != this.level) {
 			return this;
 		}
+		if(start < end && source[start] != '\\') {
+			// fast path: dispatch by first byte
+			int[] candidates = byteDispatch[source[start] & 0xFF];
+			if(candidates != null) {
+				byte[][] fieldNameBytes = this.fieldNameBytes;
+				for(int idx : candidates) {
+					if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameBytes[idx])) {
+						return next[idx];
+					}
+				}
+			}
+			return any;
+		}
+		// slow path: encoded key or empty key
 		byte[][] fieldNameBytes = this.fieldNameBytes;
 		for(int i = 0; i < fieldNameBytes.length; i++) {
 			if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameBytes[i])) {
@@ -56,6 +115,18 @@ public class StarMultiPathItem extends PathItem {
 	public PathItem matchPath(int level, char[] source, int start, int end) {
 		if(level != this.level) {
 			return this;
+		}
+		if(start < end && source[start] != '\\') {
+			int[] candidates = charDispatch[source[start] & 0xFF];
+			if(candidates != null) {
+				char[][] fieldNameChars = this.fieldNameChars;
+				for(int idx : candidates) {
+					if(AbstractPathJsonFilter.matchPath(source, start, end, fieldNameChars[idx])) {
+						return next[idx];
+					}
+				}
+			}
+			return any;
 		}
 		char[][] fieldNameChars = this.fieldNameChars;
 		for(int i = 0; i < fieldNameChars.length; i++) {

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFilters.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFilters.java
@@ -29,91 +29,99 @@ public class AnyPathFilters {
 			}
 			map.put(anyPathFilter.pathString, anyPathFilter.filterType);
 		}
-		
-		AnyPathFilter[][] exactFiltersBytes = fillBytes(any, maxKeyLengthBytes);
-		AnyPathFilter[][] exactFiltersChars = fillChars(any, maxKeyLengthChars);
-		
-		AnyPathFilter[][] encodedFiltersChars = fillEncoded(exactFiltersChars);
-		AnyPathFilter[][] encodedFiltersBytes = fillEncoded(exactFiltersBytes);
+
+		// flat structures (length → filters) are needed by fillEncoded
+		AnyPathFilter[][] flatFiltersBytes = fillFlat(any, maxKeyLengthBytes, false);
+		AnyPathFilter[][] flatFiltersChars = fillFlat(any, maxKeyLengthChars, true);
+
+		// 3D structures add a first-byte dimension for O(1) exact lookup
+		AnyPathFilter[][][] exactFiltersBytes = fillExact(any, maxKeyLengthBytes, false);
+		AnyPathFilter[][][] exactFiltersChars = fillExact(any, maxKeyLengthChars, true);
+
+		AnyPathFilter[][] encodedFiltersBytes = fillEncoded(flatFiltersBytes);
+		AnyPathFilter[][] encodedFiltersChars = fillEncoded(flatFiltersChars);
 		
 		return new AnyPathFilters(exactFiltersBytes, exactFiltersChars, encodedFiltersBytes, encodedFiltersChars, map);
 	}
-	
 
-	private static AnyPathFilter[][] fillEncoded(AnyPathFilter[][] exactFiltersChars) {
-		AnyPathFilter[][] result = new AnyPathFilter[exactFiltersChars.length + 1][];
-
-		List<AnyPathFilter> filters = new ArrayList<>();
-		
-		for(int i = exactFiltersChars.length - 1; i >= 0; i--) {
-			if(exactFiltersChars[i] != null) {
-				for(AnyPathFilter f : exactFiltersChars[i]) {
-					filters.add(f);
-				}
+	/** Builds a flat length-indexed structure used by {@link #fillEncoded}. */
+	@SuppressWarnings("unchecked")
+	private static AnyPathFilter[][] fillFlat(List<AnyPathFilter> any, int maxLength, boolean useChars) {
+		List<AnyPathFilter>[] output = new List[maxLength + 1];
+		for(int i = 0; i < output.length; i++) {
+			output[i] = new ArrayList<>();
+		}
+		for(AnyPathFilter filter : any) {
+			int len = useChars ? filter.pathChars.length : filter.pathBytes.length;
+			output[len].add(filter);
+		}
+		AnyPathFilter[][] result = new AnyPathFilter[maxLength + 1][];
+		for(int i = 0; i < result.length; i++) {
+			if(!output[i].isEmpty()) {
+				result[i] = output[i].toArray(new AnyPathFilter[0]);
 			}
-			result[i + 1] = filters.toArray(new AnyPathFilter[filters.size()]);
 		}
 		return result;
 	}
 
-	private static AnyPathFilter[][] fillBytes(List<AnyPathFilter> any, int length) {
-		List<AnyPathFilter>[] output = new List[length+1];
-		for(int i = 0; i < output.length; i++) {
-			output[i] = new ArrayList<>();
-		}
-		
+	/**
+	 * Builds a 3D structure: {@code [length][firstByte & 0xFF] → AnyPathFilter[]}.
+	 * <p>Within each length bucket, filters are partitioned by the first byte (or char)
+	 * of their path value.  A lookup then needs to scan only the sub-bucket whose first
+	 * byte matches the candidate key, reducing comparisons from O(N) to O(N / alphabet).
+	 */
+	private static AnyPathFilter[][][] fillExact(List<AnyPathFilter> any, int maxLength, boolean useChars) {
+		AnyPathFilter[][][] result = new AnyPathFilter[maxLength + 1][][];
 		for(AnyPathFilter filter : any) {
-			output[filter.pathBytes.length].add(filter);
-		}
-		
-		AnyPathFilter[][] result = new AnyPathFilter[length + 1][];
-		for(int i = 0; i < result.length; i++) {
-			if(!output[i].isEmpty()) {
-				result[i] = output[i].toArray(new AnyPathFilter[output[i].size()]);
+			int len  = useChars ? filter.pathChars.length : filter.pathBytes.length;
+			int first = useChars
+					? (filter.pathChars.length > 0 ? filter.pathChars[0] & 0xFF : 0)
+					: (filter.pathBytes.length > 0 ? filter.pathBytes[0] & 0xFF : 0);
+			if(result[len] == null) {
+				result[len] = new AnyPathFilter[256][];
+			}
+			AnyPathFilter[] existing = result[len][first];
+			if(existing == null) {
+				result[len][first] = new AnyPathFilter[]{filter};
+			} else {
+				AnyPathFilter[] updated = Arrays.copyOf(existing, existing.length + 1);
+				updated[existing.length] = filter;
+				result[len][first] = updated;
 			}
 		}
-	
-		 return result;
+		return result;
 	}
-	
-	private static AnyPathFilter[][] fillChars(List<AnyPathFilter> any, int length) {
-		List<AnyPathFilter>[] output = new List[length+1];
-		for(int i = 0; i < output.length; i++) {
-			output[i] = new ArrayList<>();
-		}
-		
-		for(AnyPathFilter filter : any) {
-			output[filter.pathChars.length].add(filter);
-		}
-		
-		AnyPathFilter[][] result = new AnyPathFilter[length + 1][];
-		for(int i = 0; i < result.length; i++) {
-			if(!output[i].isEmpty()) {
-				result[i] = output[i].toArray(new AnyPathFilter[output[i].size()]);
+
+	private static AnyPathFilter[][] fillEncoded(AnyPathFilter[][] flatFilters) {
+		AnyPathFilter[][] result = new AnyPathFilter[flatFilters.length + 1][];
+		List<AnyPathFilter> filters = new ArrayList<>();
+		for(int i = flatFilters.length - 1; i >= 0; i--) {
+			if(flatFilters[i] != null) {
+				for(AnyPathFilter f : flatFilters[i]) {
+					filters.add(f);
+				}
 			}
+			result[i + 1] = filters.toArray(new AnyPathFilter[0]);
 		}
-	
-		 return result;
+		return result;
 	}
-	
-	// for exact match
-	protected final AnyPathFilter[][] exactFiltersBytes;
-	protected final AnyPathFilter[][] exactFiltersChars;
+
+	/** Exact-match lookup: {@code [length][firstByte] → candidates}. */
+	protected final AnyPathFilter[][][] exactFiltersBytes;
+	protected final AnyPathFilter[][][] exactFiltersChars;
 
 	protected final AnyPathFilter[][] encodingFiltersBytes;
 	protected final AnyPathFilter[][] encodingFiltersChars;
 
 	protected final Map<String, FilterType> names;
 	
-	public AnyPathFilters(AnyPathFilter[][] exactFiltersBytes, AnyPathFilter[][] exactFiltersChars,
+	public AnyPathFilters(AnyPathFilter[][][] exactFiltersBytes, AnyPathFilter[][][] exactFiltersChars,
 			AnyPathFilter[][] encodingFiltersBytes, AnyPathFilter[][] encodingFiltersChars, Map<String, FilterType> names) {
 		super();
 		this.exactFiltersBytes = exactFiltersBytes;
 		this.exactFiltersChars = exactFiltersChars;
-		
 		this.encodingFiltersBytes = encodingFiltersBytes;
 		this.encodingFiltersChars = encodingFiltersChars;
-		
 		this.names = names;
 	}
 
@@ -123,14 +131,20 @@ public class AnyPathFilters {
 	
 	public FilterType matchPath(final byte[] chars, int start, int end) {
 		int length = end - start;
-		if(length < exactFiltersBytes.length && exactFiltersBytes[length] != null) {
-			FilterType type = unencodedMatchAnyElements(exactFiltersBytes[length], chars, start, end);
-			if(type != null) {
-				return type;
+		if(length > 0 && length < exactFiltersBytes.length) {
+			AnyPathFilter[][] lengthBucket = exactFiltersBytes[length];
+			if(lengthBucket != null) {
+				AnyPathFilter[] candidates = lengthBucket[chars[start] & 0xFF];
+				if(candidates != null) {
+					FilterType type = unencodedMatchBytes(candidates, chars, start);
+					if(type != null) {
+						return type;
+					}
+				}
 			}
 		}
-		
-		// check for encoded key
+
+		// check for encoded key (rare: JSON field names with Unicode escapes)
 		for(int i = start; i < end; i++) {
 			if(chars[i] == '\\') {
 				int readLength = i - start;
@@ -150,13 +164,19 @@ public class AnyPathFilters {
 	
 	public FilterType matchPath(final char[] chars, int start, int end) {
 		int length = end - start;
-		if(length < exactFiltersChars.length && exactFiltersChars[length] != null) {
-			FilterType type = unencodedMatchAnyElements(exactFiltersChars[length], chars, start, end);
-			if(type != null) {
-				return type;
+		if(length > 0 && length < exactFiltersChars.length) {
+			AnyPathFilter[][] lengthBucket = exactFiltersChars[length];
+			if(lengthBucket != null) {
+				AnyPathFilter[] candidates = lengthBucket[chars[start] & 0xFF];
+				if(candidates != null) {
+					FilterType type = unencodedMatchChars(candidates, chars, start);
+					if(type != null) {
+						return type;
+					}
+				}
 			}
 		}
-		
+
 		// check for encoded key, which should be quite rare
 		for(int i = start; i < end; i++) {
 			if(chars[i] == '\\') {
@@ -164,7 +184,6 @@ public class AnyPathFilters {
 				if(readLength >= encodingFiltersChars.length) {
 					return null;
 				}
-				
 				for(AnyPathFilter filter : encodingFiltersChars[readLength]) {
 					if(AbstractMultiPathJsonFilter.matchesEncoded(chars, start, end, filter.pathChars)) {
 						return filter.getFilterType();
@@ -175,33 +194,31 @@ public class AnyPathFilters {
 		
 		return null;
 	}
-	
 
-	protected static FilterType unencodedMatchAnyElements(AnyPathFilter[] anyPathFilters, final byte[] chars, int start, int end) {
+	private static FilterType unencodedMatchBytes(AnyPathFilter[] candidates, final byte[] chars, int start) {
 		main:
-		for(int i = 0; i < anyPathFilters.length; i++) {
-			byte[] pathBytes = anyPathFilters[i].pathBytes;
+		for(int i = 0; i < candidates.length; i++) {
+			byte[] pathBytes = candidates[i].pathBytes;
 			for(int k = 0; k < pathBytes.length; k++) {
 				if(pathBytes[k] != chars[start + k]) {
 					continue main;
 				}
 			}
-			return anyPathFilters[i].filterType;
+			return candidates[i].filterType;
 		}
 		return null;
 	}
 
-	protected static FilterType unencodedMatchAnyElements(AnyPathFilter[] anyPathFilters, final char[] chars, int start, int end) {
-		
+	private static FilterType unencodedMatchChars(AnyPathFilter[] candidates, final char[] chars, int start) {
 		main:
-		for(int i = 0; i < anyPathFilters.length; i++) {
-			char[] pathBytes = anyPathFilters[i].pathChars;
-			for(int k = 0; k < pathBytes.length; k++) {
-				if(pathBytes[k] != chars[start + k]) {
+		for(int i = 0; i < candidates.length; i++) {
+			char[] pathChars = candidates[i].pathChars;
+			for(int k = 0; k < pathChars.length; k++) {
+				if(pathChars[k] != chars[start + k]) {
 					continue main;
 				}
 			}
-			return anyPathFilters[i].filterType;
+			return candidates[i].filterType;
 		}
 		return null;
 	}

--- a/base/src/main/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFilters.java
+++ b/base/src/main/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFilters.java
@@ -103,6 +103,9 @@ public class AnyPathFilters {
 			}
 			result[i + 1] = filters.toArray(new AnyPathFilter[0]);
 		}
+		// result[0] covers keys whose very first character is a backslash (escape at offset 0).
+		// All non-empty filters are candidates in that case.
+		result[0] = filters.toArray(new AnyPathFilter[0]);
 		return result;
 	}
 

--- a/base/src/test/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFiltersTest.java
+++ b/base/src/test/java/com/github/skjolber/jsonfilter/base/path/any/AnyPathFiltersTest.java
@@ -48,5 +48,22 @@ public class AnyPathFiltersTest {
 		byte[] bytes = def.getBytes(StandardCharsets.UTF_8);
 		assertEquals(anyPathFilters.matchPath(bytes, 0, bytes.length), FilterType.ANON);
 	}
-	
+
+	/**
+	 * Verifies that a JSON Unicode escape sequence at offset 0 (entire key is encoded from
+	 * the first character) does not throw a NullPointerException.  Before the fix,
+	 * {@code encodingFilters[0]} was never initialised, causing an NPE when the backslash
+	 * appeared as the very first byte of the key.
+	 */
+	@Test
+	public void testMatchEscapedFirstChar() {
+		AnyPathFilters f = AnyPathFilters.create(AnyPathFilter.create("name", FilterType.ANON));
+
+		// 'n' = 0x006E — encoded with uppercase hex so this test is independent of
+		// the separate case-sensitivity fix in matchesEncoded.
+		String firstEncoded = "\\u006Eame";
+		assertEquals(FilterType.ANON, f.matchPath(firstEncoded.toCharArray(), 0, firstEncoded.length()));
+		assertEquals(FilterType.ANON, f.matchPath(firstEncoded.getBytes(StandardCharsets.UTF_8), 0, firstEncoded.length()));
+	}
+
 }


### PR DESCRIPTION
## Problem

`AnyPathFilters.fillEncoded` builds a cumulative array indexed by the number of unescaped bytes before the first backslash. Index 0 covers keys whose very first character is a backslash (i.e. the entire key is Unicode-escaped, e.g. `\u006eame` → `name`).

That slot was never populated — the loop ran from `length-1` down to `0` and only wrote `result[i+1]` — leaving `result[0]` as `null`. Any JSON document containing a field whose name begins with `\\` triggers a `NullPointerException`.

## Fix

After the loop, `filters` already holds all non-empty candidates. Assign `result[0] = filters.toArray(new AnyPathFilter[0])` before returning.

## Test

Added `AnyPathFiltersTest.testMatchEscapedFirstChar`: creates a filter for `"name"` and matches it against `\\u006Eame` (uppercase hex, independent of the separate case-sensitivity fix) via both `byte[]` and `char[]` paths.